### PR TITLE
Enhancement: Threaded Queue Mode for CamGear Class

### DIFF
--- a/vidgear/gears/camgear.py
+++ b/vidgear/gears/camgear.py
@@ -28,7 +28,7 @@ from threading import Thread
 from pkg_resources import parse_version
 from .helper import capPropId
 from .helper import check_CV_version
-import re, time, os
+import re, time
 
 #Note: Remember, Not all parameters are supported by all cameras which is 
 #one of the most troublesome part of the OpenCV library. Each camera type, 

--- a/vidgear/gears/camgear.py
+++ b/vidgear/gears/camgear.py
@@ -28,7 +28,7 @@ from threading import Thread
 from pkg_resources import parse_version
 from .helper import capPropId
 from .helper import check_CV_version
-import re
+import re, time, os
 
 #Note: Remember, Not all parameters are supported by all cameras which is 
 #one of the most troublesome part of the OpenCV library. Each camera type, 
@@ -73,7 +73,12 @@ class CamGear:
 	"""
 	This class targets any common IP or USB Cameras(including Raspberry Pi Compatible), 
 	Various Video Files Formats and Network Video Streams(Including Gstreamer Raw Video Capture Pipeline) 
-	for obtaining high-speed real-time frames by utilizing OpenCV and multi-threading. Now, it also supports Youtube Streaming.
+	for obtaining high-speed real-time frames by utilizing OpenCV and multi-threading. It also supports Youtube Streaming.
+	It operates in `Threaded Queue Mode` by default.
+
+	Threaded Queue Mode => Sequentially adds and releases frames to/from deque and handles overflow of this queue. It utilizes 
+	Deques that support thread-safe, memory efficient appends and pops from either side of the deque with approximately the 
+	same O(1) performance in either direction.  
 
 	:param source : take the source value. Its default value is 0. Valid Inputs are:
 
@@ -102,8 +107,11 @@ class CamGear:
 						/ This delay is essentially required for camera to warm-up. 
 						/Its default value is 0.
 	"""
+
 	def __init__(self, source = 0, y_tube = False, backend = 0, colorspace = None, logging = False, time_delay = 0, **options):
 
+		#intialize threaded queue mode
+		self.threaded_queue_mode = True
 
 		# check if Youtube Mode is ON (True)
 		if y_tube:
@@ -130,6 +138,28 @@ class CamGear:
 		# youtube mode variable initialization
 		self.youtube_mode = y_tube
 
+		#User-Defined Threaded Queue Mode
+		if options:
+			if "THREADED_QUEUE_MODE" in options:
+				if isinstance(options["THREADED_QUEUE_MODE"],bool):
+					self.threaded_queue_mode = options["THREADED_QUEUE_MODE"] #assigsn special parameter to global variable
+				del options["THREADED_QUEUE_MODE"] #clean
+				#reformat option dict
+
+		self.queue = None
+		#intialize deque for video files only 
+		if self.threaded_queue_mode and isinstance(source,str):
+			#import deque
+			from collections import deque
+			#define deque and assign it to global var
+			self.queue = deque(maxlen=64) #max len 64 to check overflow
+			#log it
+			if logging:
+				print('Enabling Threaded Queue Mode for the current video source!') 
+		else:
+			#otherwise disable it
+			self.threaded_queue_mode = False
+
 		# stream variable initialization
 		self.stream = None
 
@@ -149,12 +179,10 @@ class CamGear:
 		#initializing colorspace variable
 		self.color_space = None
 
-		#reformat dict
-		options = {k.strip(): v for k,v in options.items()}
-
-
 		try: 
 			# try to apply attributes to source if specified
+			#reformat dict
+			options = {k.strip(): v for k,v in options.items()}
 			for key, value in options.items():
 				self.stream.set(capPropId(key),value)
 
@@ -181,9 +209,12 @@ class CamGear:
 		#frame variable initialization
 		(grabbed, self.frame) = self.stream.read()
 
+		if self.threaded_queue_mode:
+			#intitialize and append to queue
+			self.queue.append(self.frame)
+
 		# applying time delay to warm-up webcam only if specified
 		if time_delay:
-			import time
 			time.sleep(time_delay)
 
 		# enable logging if specified
@@ -195,6 +226,8 @@ class CamGear:
 		# initialize termination flag
 		self.terminate = False
 
+
+
 	def start(self):
 		"""
 		start the thread to read frames from the video stream
@@ -204,15 +237,26 @@ class CamGear:
 		self.thread.start()
 		return self
 
+
+
 	def update(self):
 		"""
 		Update frames from stream
 		"""
-		# keep looping infinitely until the thread is terminated
+
+		# keep iterating infinitely until the thread is terminated or frames runs out
 		while True:
 			# if the thread indicator variable is set, stop the thread
 			if self.terminate:
 				break
+
+			if self.threaded_queue_mode:
+				#check queue buffer for overflow
+				if len(self.queue) < 64:
+					pass
+				else:
+					#stop iterating if overflowing occurs
+					continue
 
 			# otherwise, read the next frame from the stream
 			(grabbed, frame) = self.stream.read()
@@ -220,7 +264,13 @@ class CamGear:
 			#check for valid frames
 			if not grabbed:
 				#no frames received, then safely exit
-				self.terminate = True
+				if self.threaded_queue_mode:
+					if len(self.queue)>0:
+						pass
+					else:
+						self.terminate = True
+				else:
+					self.terminate = True
 
 			if not(self.color_space is None):
 				# apply colorspace to frames
@@ -245,20 +295,38 @@ class CamGear:
 					self.frame = frame
 			else:
 				self.frame = frame
-				
+
+			#append to queue
+			if self.threaded_queue_mode:
+				self.queue.append(frame)
+
 		#release resources
 		self.stream.release()
+
+
 
 	def read(self):
 		"""
 		return the frame
 		"""
+		if self.threaded_queue_mode:
+			if len(self.queue)>0:
+				return self.queue.popleft()
 		return self.frame
+
+
 
 	def stop(self):
 		"""
 		Terminates the Read process
 		"""
+
+		#terminate Threaded queue mode seperately
+		if self.threaded_queue_mode and not(self.queue is None):
+			self.queue.clear()
+			self.threaded_queue_mode = False
+			self.frame = None
+
 		# indicate that the thread should be terminate
 		self.terminate = True
 		# wait until stream resources are released (producer thread might be still grabbing frame)

--- a/vidgear/tests/benchmark_tests/test_benchmark_Videocapture.py
+++ b/vidgear/tests/benchmark_tests/test_benchmark_Videocapture.py
@@ -64,7 +64,8 @@ def Videocapture_withVidGear(path):
 	"""
 	Function to benchmark VidGear multi-threaded video playback 
 	"""
-	stream = CamGear(source=path).start()
+	options = {'THREADED_QUEUE_MODE':False}
+	stream = CamGear(source=path, **options).start()
 	fps_Vid = FPS().start()
 	while True:
 		frame = stream.read()

--- a/vidgear/tests/benchmark_tests/test_benchmark_Videowriter.py
+++ b/vidgear/tests/benchmark_tests/test_benchmark_Videowriter.py
@@ -59,7 +59,8 @@ def Videowriter_non_compression_mode(path):
 	"""
 	Function to Benchmark VidGearwriter - (Non-Compression Mode: OpenCV)
 	"""
-	stream = VideoGear(source=path).start() 
+	options = {'THREADED_QUEUE_MODE':False}
+	stream = VideoGear(source=path, **options).start() 
 	writer = WriteGear(output_filename = 'Output_vnc.mp4', compression_mode = False )
 	fps_CV = FPS().start()
 	while True:
@@ -82,7 +83,8 @@ def Videowriter_compression_mode(path):
 	"""
 	Function to Benchmark VidGearwriter - (Compression Mode: FFmpeg)
 	"""
-	stream = VideoGear(source=path).start()
+	options = {'THREADED_QUEUE_MODE':False}
+	stream = VideoGear(source=path, **options).start()
 	writer = WriteGear(output_filename = 'Output_vc.mp4', custom_ffmpeg = return_static_ffmpeg())
 	fps_Vid = FPS().start()
 	while True:

--- a/vidgear/tests/benchmark_tests/test_benchmark_playback.py
+++ b/vidgear/tests/benchmark_tests/test_benchmark_playback.py
@@ -46,7 +46,8 @@ def playback(level):
 	"""
 	Function to test VidGear playback capabilities
 	"""
-	stream = CamGear(source=level).start()
+	options = {'THREADED_QUEUE_MODE':False}
+	stream = CamGear(source=level, **options).start()
 	fps = FPS().start()
 	while True:
 		frame = stream.read()

--- a/vidgear/tests/videocapture_tests/test_camgear.py
+++ b/vidgear/tests/videocapture_tests/test_camgear.py
@@ -78,6 +78,7 @@ def test_threaded_queue_mode():
 	Test for New Thread Queue Mode in CamGear Class
 	"""
 	actual_frame_num = return_total_frame_count()
+
 	stream_camgear = CamGear(source=return_testvideo_path(), logging=True).start() #start stream on CamGear
 	camgear_frames_num = 0
 	while True:
@@ -105,7 +106,8 @@ def test_youtube_playback():
 		result = True
 		try:
 			true_video_param = return_youtubevideo_params(Url)
-			stream = CamGear(source=Url, y_tube = True, logging=True).start() # YouTube Video URL as input
+			options = {'THREADED_QUEUE_MODE':False}
+			stream = CamGear(source=Url, y_tube = True, logging=True, **options).start() # YouTube Video URL as input
 			height = 0
 			width = 0
 			fps = 0
@@ -133,7 +135,8 @@ def test_network_playback():
 	"""	
 	Url = 'rtsp://184.72.239.149/vod/mp4:BigBuckBunny_175k.mov'
 	try:
-		output_stream = CamGear(source = Url).start()
+		options = {'THREADED_QUEUE_MODE':False}
+		output_stream = CamGear(source = Url, **options).start()
 		i = 0
 		Output_data = []
 		while i<10:

--- a/vidgear/tests/videocapture_tests/test_camgear.py
+++ b/vidgear/tests/videocapture_tests/test_camgear.py
@@ -86,7 +86,7 @@ def test_threaded_queue_mode():
 			print(camgear_frames_num)
 			break
 		
-		time.sleep(1) #dummy computational task cycling at 1 loop/sec
+		time.sleep(0.2) #dummy computational task
 
 		camgear_frames_num += 1
 	stream_camgear.stop()
@@ -105,7 +105,7 @@ def test_youtube_playback():
 		result = True
 		try:
 			true_video_param = return_youtubevideo_params(Url)
-			stream = CamGear(source=Url, y_tube = True,  time_delay=2, logging=True).start() # YouTube Video URL as input
+			stream = CamGear(source=Url, y_tube = True, logging=True).start() # YouTube Video URL as input
 			height = 0
 			width = 0
 			fps = 0

--- a/vidgear/tests/videocapture_tests/test_videogear.py
+++ b/vidgear/tests/videocapture_tests/test_videogear.py
@@ -45,7 +45,8 @@ def test_CamGear_import():
 	"""
 	try:
 		Url = 'rtsp://184.72.239.149/vod/mp4:BigBuckBunny_175k.mov'
-		output_stream = VideoGear(source = Url).start()
+		options = {'THREADED_QUEUE_MODE':False}
+		output_stream = VideoGear(source = Url, **options).start()
 		output_stream.stop()
 	except Exception as e:
 		pytest.fail(str(e))


### PR DESCRIPTION
## PR Summary:
This PR introduces **Threaded Queue Mode for CamGear Class(_works with VideoGear Common Class too_), that enables Blocking use of the source in Fixed-Length Video Streams.** This Mode is enabled by default for any Videocapture stream(_except any connected Camera/H.W devices_). 

### Manually Disabling/Enabling of Threaded Queue Mode:
To manually alter this mode, CamGear Class now provides **`THREADED_QUEUE_MODE`** user-defined flag. This flag can be easily set to `True`(_to enable_) or unset to `False`_(to disable_) this mode by passing this parameter to [`**options`](https://github.com/abhiTronix/vidgear/wiki/CamGear-Class#parameters-and-attributes-wrench) dict of CamGear class as follows:

```python
options = {'THREADED_QUEUE_MODE': False} #to disable Threaded Queue Mode
```

### Features:
- Enables Blocking, Sequential and Threaded LIFO Frame Handling.
- It Sequentially adds and releases frames to/from deque and handles the overflow of this queue.
- It utilizes deques that support thread-safe, memory efficient appends and pops from either side of the deque with approximately the same O(1) performance in either direction.
- Requires less RAM at due to buffered frames in the deque.

### Drawbacks:
* Direct Colorspace conversion/manipulation may result in delayed/incorrect results, only when this mode is activated
* Cannot be applied to Camera Feed/H.W. Devices.

### Solves:
#20 

### TODO
- [x] Implement a **Blocking Mode** in CamGear Class with a threaded queue
- [x] Use `collections.deque()` for performance consideration
- [x] Add a test for this Mode
- [x] Update Wiki
- [x] Fix Bugs and robust testing of this implementation.
