### PR TITLE
Enhancement: Introducing powerful ZMQ Authentication & Data Encryption features for NetGear API

### DIFF
--- a/vidgear/gears/helper.py
+++ b/vidgear/gears/helper.py
@@ -251,3 +251,106 @@ def check_output(*args, **kwargs):
 		error.output = output
 		raise error
 	return output
+
+
+def generate_auth_certificates(path, overwrite = False):
+	""" Generate client and server CURVE ZMQ certificate files """
+
+	import shutil, errno
+	import zmq.auth
+
+	if (os.path.basename(path) != ".vidgear"):
+		path = os.path.join(path,".vidgear")
+
+	keys_dir = os.path.join(path, 'keys')
+	try:
+		os.makedirs(keys_dir)
+	except OSError as e:
+		if e.errno != errno.EEXIST:
+			raise
+
+	public_keys_dir = os.path.join(keys_dir, 'public_keys')
+	secret_keys_dir = os.path.join(keys_dir, 'private_keys')
+
+	if overwrite:
+
+		for d in [public_keys_dir, secret_keys_dir]:
+			if os.path.exists(d):
+				shutil.rmtree(d)
+			os.mkdir(d)
+
+		# create new keys in certificates dir
+		server_public_file, server_secret_file = zmq.auth.create_certificates(keys_dir, "server")
+		client_public_file, client_secret_file = zmq.auth.create_certificates(keys_dir, "client")
+
+		# move public keys to appropriate directory
+		for key_file in os.listdir(keys_dir):
+			if key_file.endswith(".key"):
+				shutil.move(os.path.join(keys_dir, key_file), public_keys_dir)
+			elif key_file.endswith(".key_secret"):
+				shutil.move(os.path.join(keys_dir, key_file), public_keys_dir)
+			else:
+				os.remove(key_file)
+
+	else:
+
+		status_public_keys = validate_auth_keys(public_keys_dir, '.key')
+		status_private_keys = validate_auth_keys(secret_keys_dir, '.key_secret')
+
+		if status_private_keys and status_public_keys:
+			return keys_dir
+
+		if not(status_public_keys):
+			try:
+				os.makedirs(public_keys_dir)
+			except OSError as e:
+				if e.errno != errno.EEXIST:
+					raise
+
+		if not(status_private_keys): 
+			try:
+				os.makedirs(secret_keys_dir)
+			except OSError as e:
+				if e.errno != errno.EEXIST:
+					raise
+
+		# create new keys in certificates dir
+		server_public_file, server_secret_file = zmq.auth.create_certificates(keys_dir, "server")
+		client_public_file, client_secret_file = zmq.auth.create_certificates(keys_dir, "client")
+
+
+		# move public keys to appropriate directory
+		for key_file in os.listdir(keys_dir):
+			if key_file.endswith(".key") and not(status_public_keys):
+				shutil.move(os.path.join(keys_dir, key_file), os.path.join(public_keys_dir, '.'))
+			elif key_file.endswith(".key_secret") and not(status_private_keys):
+				shutil.move(os.path.join(keys_dir, key_file), os.path.join(secret_keys_dir, '.'))
+			else:
+				redundant_key = os.path.join(keys_dir,key_file)
+				if os.path.isfile(redundant_key):
+					os.remove(redundant_key)
+
+	status_public_keys = validate_auth_keys(public_keys_dir, '.key')
+	status_private_keys = validate_auth_keys(secret_keys_dir, '.key_secret')
+
+	if not(status_private_keys) or not(status_public_keys):
+		raise RuntimeError('[Error]: Unable to create ZMQ all authentication certificates at `{}`!'.format(keys_dir))
+
+	return keys_dir
+
+
+def validate_auth_keys(path, extension):
+
+	if not(os.path.exists(path)): return False
+	if not(os.listdir(path)): return False
+
+	keys_buffer = []
+
+	for key_file in os.listdir(path):
+		key = os.path.splitext(key_file)
+		if key and (key[0] in ['server','client']) and (key[1] == extension):
+			keys_buffer.append(key_file)
+
+	if(len(keys_buffer) == 1): os.remove(os.path.join(path,keys_buffer[0])) 
+
+	return True if(len(keys_buffer) == 2) else False

--- a/vidgear/gears/helper.py
+++ b/vidgear/gears/helper.py
@@ -288,17 +288,18 @@ def generate_auth_certificates(path, overwrite = False):
 			if key_file.endswith(".key"):
 				shutil.move(os.path.join(keys_dir, key_file), public_keys_dir)
 			elif key_file.endswith(".key_secret"):
-				shutil.move(os.path.join(keys_dir, key_file), public_keys_dir)
+				shutil.move(os.path.join(keys_dir, key_file), secret_keys_dir)
 			else:
-				os.remove(key_file)
-
+				redundant_key = os.path.join(keys_dir,key_file)
+				if os.path.isfile(redundant_key):
+					os.remove(redundant_key)
 	else:
 
 		status_public_keys = validate_auth_keys(public_keys_dir, '.key')
 		status_private_keys = validate_auth_keys(secret_keys_dir, '.key_secret')
 
 		if status_private_keys and status_public_keys:
-			return keys_dir
+			return (keys_dir, secret_keys_dir, public_keys_dir)
 
 		if not(status_public_keys):
 			try:
@@ -336,7 +337,7 @@ def generate_auth_certificates(path, overwrite = False):
 	if not(status_private_keys) or not(status_public_keys):
 		raise RuntimeError('[Error]: Unable to create ZMQ all authentication certificates at `{}`!'.format(keys_dir))
 
-	return keys_dir
+	return (keys_dir, secret_keys_dir, public_keys_dir)
 
 
 def validate_auth_keys(path, extension):

--- a/vidgear/gears/netgear.py
+++ b/vidgear/gears/netgear.py
@@ -284,13 +284,17 @@ class NetGear:
 				port = '5555'
 
 			try:
-				if self.secure_mode == 2 and not(self.multiserver_mode):
+				if self.secure_mode > 0 and not(self.multiserver_mode):
 					# Start an authenticator for this context.
 					auth = ThreadAuthenticator(self.msg_context)
 					auth.start()
 					auth.allow(str(address))
 					# Tell authenticator to use the certificate in a directory
-					auth.configure_curve(domain='*', location=self.auth_publickeys_dir)
+					if self.secure_mode == 2:
+						auth.configure_curve(domain='*', location=self.auth_publickeys_dir)
+					else:
+						# Tell the authenticator how to handle CURVE requests
+						auth.configure_curve(domain='*', location=zmq.auth.CURVE_ALLOW_ANY)
 
 				# initialize and define thread-safe messaging socket
 				self.msg_socket = self.msg_context.socket(msg_pattern[1])
@@ -298,7 +302,7 @@ class NetGear:
 				if self.multiserver_mode:
 					#if multiserver_mode is enabled assign port addresses to zmq socket
 					for pt in port:
-						if self.secure_mode == 2: #IronHouse security mechanism
+						if self.secure_mode > 0: 
 							client_secret_file = os.path.join(self.auth_secretkeys_dir, "client.key_secret")
 							client_public, client_secret = zmq.auth.load_certificate(client_secret_file)
 							self.msg_socket.curve_secretkey = client_secret
@@ -316,7 +320,7 @@ class NetGear:
 				else:
 					# otherwise bind socket to given protocol, address and port normally
 
-					if self.secure_mode == 2: #IronHouse security mechanism
+					if self.secure_mode > 0:
 						server_secret_file = os.path.join(self.auth_secretkeys_dir, "server.key_secret")
 						server_public, server_secret = zmq.auth.load_certificate(server_secret_file)
 						self.msg_socket.curve_secretkey = server_secret
@@ -371,19 +375,23 @@ class NetGear:
 				port = 5555  #define port normally
 				
 			try:
-				if self.secure_mode == 2 and self.multiserver_mode:
+				if self.secure_mode > 0 and self.multiserver_mode:
 					# Start an authenticator for this context.
 					auth = ThreadAuthenticator(self.msg_context)
 					auth.start()
 					auth.allow(str(address))
 					# Tell authenticator to use the certificate in a directory
-					auth.configure_curve(domain='*', location=self.auth_publickeys_dir)
+					if self.secure_mode == 2:
+						auth.configure_curve(domain='*', location=self.auth_publickeys_dir)
+					else:
+						# Tell the authenticator how to handle CURVE requests
+						auth.configure_curve(domain='*', location=zmq.auth.CURVE_ALLOW_ANY)
 
 				# initialize and define thread-safe messaging socket
 				self.msg_socket = self.msg_context.socket(msg_pattern[0])
 
 				if self.multiserver_mode:
-					if self.secure_mode == 2: #IronHouse security mechanism
+					if self.secure_mode > 0: 
 						server_secret_file = os.path.join(self.auth_secretkeys_dir, "server.key_secret")
 						server_public, server_secret = zmq.auth.load_certificate(server_secret_file)
 						self.msg_socket.curve_secretkey = server_secret
@@ -397,7 +405,7 @@ class NetGear:
 						self.msg_socket.REQ_RELAXED = True
 						self.msg_socket.REQ_CORRELATE = True
 
-					if self.secure_mode == 2: #IronHouse security mechanism
+					if self.secure_mode > 0: 
 						client_secret_file = os.path.join(self.auth_secretkeys_dir, "client.key_secret")
 						client_public, client_secret = zmq.auth.load_certificate(client_secret_file)
 						self.msg_socket.curve_secretkey = client_secret

--- a/vidgear/gears/screengear.py
+++ b/vidgear/gears/screengear.py
@@ -90,7 +90,7 @@ class ScreenGear:
 		self.mss_object = mss() 
 		# create monitor instance for the user-defined monitor
 		monitor_instance = None
-		if (monitor > 0):
+		if (monitor >= 0):
 			monitor_instance = self.mss_object.monitors[monitor]
 		else:
 			raise ValueError("`monitor` value cannot be negative, Read Docs!")


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->

## Description
_This PR introduces powerful, smart & secure ZeroMQ's Security Layers for NetGear API that enables strong encryption on data, and (_as far as we know_) unbreakable authentication between Servers and Client with the help of custom auth certificates/keys._ 

**This PR introduces supports for the two most powerful ZMQ security mechanisms:**

- **Stonehouse:** which switches to the _"CURVE"_ security mechanism, giving us strong encryption on data, and (as far as we know) unbreakable authentication. Stonehouse is the minimum you would use over public networks and assures clients that they are speaking to an authentic server while allowing any client to connect. **It is less secure but faster than IronHouse security mechanism.**
- **Ironhouse:** which extends Stonehouse with client public key authentication. This is the strongest security model we have today, protecting against every attack we know about, except end-point attacks (where an attacker plants spyware on a machine to capture data before it's encrypted, or after it's decrypted). **Its enhanced security comes at a price of additional latency.**

### Important Warnings
* **:warning: This feature only supports Python 3 and above, and also `libzmq` library version >= 4.0.**
* **:warning: IronHouse Security mechanism is the strongest security model, more secure than StoneHouse or any other security mechanisms, but its enhanced security comes at the price of added _LATENCY_.**

### TODO:
- [x] add exclusive `secure_mode` for enabling this feature
- [x] add support for powerful `Stonehouse` & `Ironhouse` ZMQ security mechanisms.
- [x] implement and test `Stonehouse` ZMQ security mechanism.
- [x] implement  and test `Ironhouse` ZMQ security mechanism.
- [x] robustly test compatibility with various modes and messaging patterns.
- [x] add smart auth certificates/key generation and validation
- [x] add additional dict params for enabling various tweaks.
- [x] fix bugs related to this implementation
- [x] Update docs



### Requirements / Checklist

<!--- Put an `x` in all the boxes that apply(important): -->

- [x] Read the [Contributing Guidelines](https://github.com/abhiTronix/vidgear/blob/master/contributing.md)
- [x] Read the [FAQ](https://github.com/abhiTronix/vidgear/wiki/FAQ-&-Troubleshooting)
- [x] Comprehended the [Wiki Documentation](https://github.com/abhiTronix/vidgear/wiki#vidgear)
- [x] Updated the source-code documentation accordingly(if required).


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#46 

### Context
<!--- Why is this change required? What problem does it solve? -->
As of now, NetGear API offers no data encryption, no authentication, and no privacy at all which makes it highly vulnerable to threats like a [man-in-the-middle attack (MITM)](https://en.wikipedia.org/wiki/Man-in-the-middle_attack).  To protect against it, one way is building your own physical networks and isolating it from the public Internet. However that is extraordinarily costly. Just as ZeroMQ brought us cheap, standardized connectivity for distributed systems, our goals with the security layers are to bring cheap, standardized privacy and authentication for distributed systems in NetGear API. Therefore, this PR introduces ZeroMQ's Security Layers for NetGear API that enables strong encryption on data, and (_as far as we know_) unbreakable authentication between Servers and Client with the help of custom auth certificates / keys generated at runtime.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply(important): -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Screenshots (if available):
None




