### PR TITLE
Travis CI: Run flake8 to find undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ script:
     fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     python -m pytest --verbose --capture=no --cov-report term-missing --cov=vidgear vidgear/tests/;
-    flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics;
+    python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics;
     fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,10 +85,10 @@ install:
     pip install --upgrade pip wheel;
     pip install --upgrade numpy;
     pip install .;
-    pip uninstall opencv-contrib-python -y;
+    pip uninstall opencv-python -y;
     pip install six;
     pip install codecov;
-    pip install --upgarde flake8;
+    pip install --upgrade flake8;
     pip install --upgrade pytest;
     pip install --upgrade pytest-cov;
     pip install --upgrade youtube-dl;
@@ -101,7 +101,7 @@ install:
     pip install --user codecov;
     pip install --upgrade --user pytest;
     pip install --upgrade --user pytest-cov;
-    pip install --upgrade  --user youtube-dl;
+    pip install --upgrade --user youtube-dl;
     fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,8 @@ script:
     fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     python -m pytest --verbose --capture=no --cov-report term-missing --cov=vidgear vidgear/tests/;
+    pip install flake8
+    flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,7 @@ install:
     pip uninstall opencv-contrib-python -y;
     pip install six;
     pip install codecov;
+    pip install --upgarde flake8;
     pip install --upgrade pytest;
     pip install --upgrade pytest-cov;
     pip install --upgrade youtube-dl;
@@ -120,8 +121,7 @@ script:
     fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     python -m pytest --verbose --capture=no --cov-report term-missing --cov=vidgear vidgear/tests/;
-    pip install flake8
-    flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics;
     fi
 
 after_success:


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->

## Description

**Add flake8 to travis to find undefined names:** https://flake8.pycqa.org/en/latest/user/error-codes.html

### Requirements / Checklist

<!--- Put an `x` in all the boxes that apply(important): -->

- [x] Read the [Contributing Guidelines](https://github.com/abhiTronix/vidgear/blob/master/contributing.md)
- [x] Read the [FAQ](https://github.com/abhiTronix/vidgear/wiki/FAQ-&-Troubleshooting)
- [x] Comprehended the [Wiki Documentation](https://github.com/abhiTronix/vidgear/wiki#vidgear)
- [x] Updated the source-code documentation accordingly(if required).


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#92

### Context
<!--- Why is this change required? What problem does it solve? -->
On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply(important): -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Screenshots (if available):

None



