### PR TITLE
Fixes for flake8 Tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## VidGear 0.1.7-alpha0
 
+### Updates/Improvements:
+  
+  * Add flake8 tests to Travis CLI to find undefined names. (@cclauss )
+
 ### Fixes:
 
   * `self` is an undefined name in helper.py context which will raise NameError. (@cclauss)
@@ -9,6 +13,7 @@
 ### Pull requests(PR) involved:
 
 #88
+#91
 
 :warning: PyPi Release does NOT contain Tests and Scripts!
 

--- a/vidgear/gears/screengear.py
+++ b/vidgear/gears/screengear.py
@@ -75,6 +75,8 @@ class ScreenGear:
 			from mss import mss
 			# import mss error handler
 			from mss.exception import ScreenShotError
+			#assign values to global variable for further use
+			self.__ScreenShotError = ScreenShotError
 		except ImportError as error:
 			# otherwise raise import error
 			raise ImportError('[ScreenGear:ERROR] :: python-mss library not found, install it with `pip install mss` command.')
@@ -139,7 +141,7 @@ class ScreenGear:
 				#intitialize and append to queue
 				self.__queue.append(self.frame)
 		except Exception as e:
-			if isinstance(e, ScreenShotError):
+			if isinstance(e, self.__ScreenShotError):
 				#otherwise catch and log errors
 				if logging: self.__logger.exception(self.__mss_object.get_error_details())
 				raise ValueError("[ScreenGear:ERROR] :: ScreenShotError caught, Wrong dimensions passed to python-mss, Kindly Refer Docs!")
@@ -183,7 +185,7 @@ class ScreenGear:
 					continue
 			try:
 				frame = np.asanyarray(self.__mss_object.grab(self.__mss_capture_instance))
-			except ScreenShotError:
+			except self.__ScreenShotError:
 				raise RuntimeError(self.__mss_object.get_error_details())
 				self.__terminate = True
 				continue

--- a/vidgear/tests/benchmark_tests/test_benchmark_Videowriter.py
+++ b/vidgear/tests/benchmark_tests/test_benchmark_Videowriter.py
@@ -106,7 +106,7 @@ def test_benchmark_videowriter():
 	Benchmarking WriteGear's optimized Compression Mode(FFmpeg) against Non-Compression Mode(OpenCV)
 	"""
 	try:
-		Videowriter_non_compression_mode(return_testvideo_path())
-		Videowriter_compression_mode(return_testvideo_path())
+		WriteGear_non_compression_mode(return_testvideo_path())
+		WriteGear_compression_mode(return_testvideo_path())
 	except Exception as e:
 		raise RuntimeError(e)

--- a/vidgear/tests/videocapture_tests/test_camgear.py
+++ b/vidgear/tests/videocapture_tests/test_camgear.py
@@ -166,4 +166,4 @@ def test_network_playback():
 			else:
 				pytest.fail(str(e))
 
-	if (index == len(Publictest_rstp_urls)): pytest.fail(str(e))
+	if (index == len(Publictest_rstp_urls)): pytest.fail("Tests failed to play any URL!")


### PR DESCRIPTION

<!--- Provide a general summary of the issue in the Title above -->

## Description

This PR aims at fixing various undefined names errors within vidgear discovered by flake8 tests.

### Requirements / Checklist

<!--- Put an `x` in all the boxes that apply(important): -->

- [x] Read the [Contributing Guidelines](https://github.com/abhiTronix/vidgear/blob/master/contributing.md)
- [x] Read the [FAQ](https://github.com/abhiTronix/vidgear/wiki/FAQ-&-Troubleshooting)
- [x] Comprehended the [Wiki Documentation](https://github.com/abhiTronix/vidgear/wiki#vidgear)
- [x] Updated the source-code documentation accordingly(if required).


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#92 

### Context
<!--- Why is this change required? What problem does it solve? -->
Vidgear recently added flake8 Tests for Travis CLI Linux environments in order to address various undefined name errors(PR #91) and thereby this PR aims at fixing them. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply(important): -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Screenshots (if available):
None



