### PR TITLE
WriteGear API: Added support for adding duplicate arguments to `output_params` parameter (Fixes #141)

### DIFF
--- a/docs/gears/netgear/advanced/bidirectional_mode.md
+++ b/docs/gears/netgear/advanced/bidirectional_mode.md
@@ -21,7 +21,7 @@ limitations under the License.
 # Advanced Usage: Bidirectional Mode for NetGear API 
 
 <h3 align="center">
-  <img src="../../../../assets/images/bidir.png" alt="Bi-directional Mode"/>
+  <img src="../../../../assets/images/bidir.png" alt="Bi-directional Mode" width="85%"/>
 </h3>
 
 ## Overview

--- a/docs/gears/netgear/advanced/compression.md
+++ b/docs/gears/netgear/advanced/compression.md
@@ -117,6 +117,7 @@ Open your favorite terminal and execute the following python code:
 # import required libraries
 from vidgear.gears import VideoGear
 from vidgear.gears import NetGear
+import cv2
 
 # open any valid video stream(for e.g `test.mp4` file)
 stream = VideoGear(source='test.mp4').start()
@@ -272,6 +273,7 @@ Now, Open the terminal on another Server System _(with a webcam connected to it 
 # import required libraries
 from vidgear.gears import VideoGear
 from vidgear.gears import NetGear
+import cv2
 
 # define decode image as 3 channel BGR color image
 options = {'compression_format': '.jpg', 'compression_param':cv2.IMREAD_COLOR}

--- a/docs/gears/netgear/advanced/compression.md
+++ b/docs/gears/netgear/advanced/compression.md
@@ -22,7 +22,7 @@ limitations under the License.
 
 
 <p align="center">
-  <img src="../../../../assets/images/compression.png" alt="Frame Compression" />
+  <img src="../../../../assets/images/compression.png" alt="Frame Compression" width="75%" />
 </p>
 
 

--- a/docs/gears/netgear/advanced/compression.md
+++ b/docs/gears/netgear/advanced/compression.md
@@ -28,9 +28,9 @@ limitations under the License.
 
 ## Overview
 
-NetGear API supports real-time Frame Compression _(Encoding/Decoding capabilities)_, for optimizing performance while sending frames over the network. This compression works by encoding the frame before sending it at Server's end, and therby, decoding it on the Client's end automatically, all in real-time.
+NetGear API supports real-time Frame Compression _(Encoding/Decoding capabilities)_, for optimizing performance while sending frames over the network. This compression works by encoding the frame before sending it at Server's end, and thereby, smartly decoding it on the Client's end, all in real-time.
 
-In Frame Compression, NetGear API utilizes OpenCV's [imencode](https://docs.opencv.org/3.4/d4/da8/group__imgcodecs.html#ga26a67788faa58ade337f8d28ba0eb19e) & [imdecode](https://docs.opencv.org/3.4/d4/da8/group__imgcodecs.html#ga26a67788faa58ade337f8d28ba0eb19e) methods in conjunction with its flexible APIs at Server and Client end respectively. Eurthrermore, this aid us to achieve better control over the compression of the frame being sent over the network, and thereby helps in optimizing the performance, but only at the cost of quality. 
+In Frame Compression, NetGear API utilizes OpenCV's [imencode](https://docs.opencv.org/3.4/d4/da8/group__imgcodecs.html#ga26a67788faa58ade337f8d28ba0eb19e) & [imdecode](https://docs.opencv.org/3.4/d4/da8/group__imgcodecs.html#ga26a67788faa58ade337f8d28ba0eb19e) methods in conjunction with its flexible APIs at Server and Client end respectively. Furthermore, this aid us to achieve better control over the compression of the frame being sent over the network, and thereby helps in optimizing the performance, but only at the cost of quality. 
 
 Frame Compression can be easily activated in NetGear API through `compression_format` & `compression_param` attributes of its [`option`](../../params/#options) dictionary parameter, during initialization.
 
@@ -39,7 +39,9 @@ Frame Compression can be easily activated in NetGear API through `compression_fo
 
 !!! warning "Important Information"
 
-    * Frame Compression only supports `JPG/JPEG`, `PNG` & `BMP` encoding formats as of now.
+    * Frame Compression only supports three `JPG` or `JPEG`, `PNG` & `BMP` encoding formats as of now.
+
+    * Any Incorrect/Invalid encoding format will **DISABLE** this Frame Compression!
 
     * Incorrect Format-specific parameters through `compression_param` attribute are skipped automatically.
 
@@ -51,7 +53,7 @@ Frame Compression can be easily activated in NetGear API through `compression_fo
 
 - [x] Enables real-time Frame Compression for further optimizing performance.
 
-- [x] Client End automatically decodes frame based on the encoding used at Server End.
+- [x] Client End intelligently decodes frame only w.r.t the encoding used at Server End.
 
 - [x] Encoding and decoding supports all Format-specific flags.
 
@@ -66,7 +68,11 @@ Frame Compression can be easily activated in NetGear API through `compression_fo
 
 For implementing Frame Compression, NetGear API currently provide following attribute for its [`option`](../../params/#options) dictionary parameter:
 
-* `compression_format` (_string_): This attribute activates compression with selected encoding format at the Server end only. Its possible valid values are: `'.jpg'`/`'.jpeg'` or `'.png'` or `'.bmp'`, and its usage is as follows:
+* `compression_format` (_string_): This attribute activates compression with selected encoding format. Its possible valid values are: `'.jpg'`/`'.jpeg'` or `'.png'` or `'.bmp'`, and its usage is as follows:
+
+    !!! warning "Any Incorrect/Invalid encoding format value on `compression_format` attribute will **DISABLE** this Frame Compression!"
+
+    !!! info "Even if you assign different `compression_format` value at Client's end, NetGear will auto-select the Server's encoding format instead."
     
     ```python
     options = {'compression_format': '.jpg'} #activates jpeg encoding
@@ -162,7 +168,7 @@ from vidgear.gears import NetGear
 import cv2
 
 # define decode image as 3 channel BGR color image
-options = {'compression_param':cv2.IMREAD_COLOR}
+options = {'compression_format': '.jpg', 'compression_param':cv2.IMREAD_COLOR}
 
 #define NetGear Client with `receive_mode = True` and defined parameter
 client = NetGear(receive_mode = True, pattern = 1, logging = True, **options)
@@ -268,7 +274,7 @@ from vidgear.gears import VideoGear
 from vidgear.gears import NetGear
 
 # define decode image as 3 channel BGR color image
-options = {'compression_param':cv2.IMREAD_COLOR}
+options = {'compression_format': '.jpg', 'compression_param':cv2.IMREAD_COLOR}
 
 # Open live video stream on webcam at first index(i.e. 0) device
 stream = VideoGear(source=0).start()

--- a/docs/gears/netgear/advanced/multi_client.md
+++ b/docs/gears/netgear/advanced/multi_client.md
@@ -24,7 +24,7 @@ limitations under the License.
 ## Overview
 
 <p align="center">
-  <img src="../../../../assets/images/multi_client.png" alt="NetGear's Multi-Clients Mode"/>
+  <img src="../../../../assets/images/multi_client.png" alt="NetGear's Multi-Clients Mode" width="75%"/>
   <br>
   <sub><i>NetGear's Multi-Clients Mode generalised</i></sub>
 </p>

--- a/docs/gears/netgear/advanced/multi_server.md
+++ b/docs/gears/netgear/advanced/multi_server.md
@@ -23,7 +23,7 @@ limitations under the License.
 ## Overview
 
 <p align="center">
-  <img src="../../../../assets/images/multi_server.png" alt="NetGear's Multi-Servers Mode"/>
+  <img src="../../../../assets/images/multi_server.png" alt="NetGear's Multi-Servers Mode" width="75%"/>
   <br>
   <sub><i>NetGear's Multi-Servers Mode generalised</i></sub>
 </p>

--- a/docs/gears/netgear/advanced/secure_mode.md
+++ b/docs/gears/netgear/advanced/secure_mode.md
@@ -21,7 +21,7 @@ limitations under the License.
 # Advanced Usage: Secure Mode for NetGear API 
 
 <p align="center">
-  <img src="../../../../assets/images/secure_mode.png" alt="Secure Mode" />
+  <img src="../../../../assets/images/secure_mode.png" alt="Secure Mode" width="75%"/>
 </p>
 
 

--- a/docs/gears/netgear/params.md
+++ b/docs/gears/netgear/params.md
@@ -150,7 +150,7 @@ This parameter provides the flexibility to alter various NetGear API's internal 
 
     * **`overwrite_cert`** (_boolean_) : In Secure Mode, This internal attribute decides whether to overwrite existing Public+Secret Keypair/Certificates or not, ==at the Server-end only==. More information can be found [here ➶](../advanced/secure_mode/#supported-attributes)
 
-    * **`compression_format`**(_string_): This internal attribute activates compression with selected encoding format at the Server end only. The possible values are `.jpg`, `.png`, `.bmp`. More information can be found [here ➶](../advanced/compression/#supported-attributes)
+    * **`compression_format`**(_string_): This internal attribute activates frame compression with selected encoding format. The possible values are `.jpg`, `.png`, `.bmp`. More information can be found [here ➶](../advanced/compression/#supported-attributes)
 
     * **`compression_param`**(_integer & list/tuple_): This internal attribute allow us to pass different format-specific [Encoding parameters](https://docs.opencv.org/3.4/d4/da8/group__imgcodecs.html#ga461f9ac09887e47797a54567df3b8b63) and [Decoding flags](https://docs.opencv.org/3.4/d4/da8/group__imgcodecs.html#ga26a67788faa58ade337f8d28ba0eb19e). More information can be found [here ➶](../advanced/compression/#supported-attributes)
 

--- a/docs/gears/writegear/compression/params.md
+++ b/docs/gears/writegear/compression/params.md
@@ -97,9 +97,7 @@ WriteGear(output_filename = 'output.mp4', custom_ffmpeg="/foo/foo1/FFmpeg")
 This parameter allows us to exploit almost all FFmpeg supported parameters effortlessly and flexibly for encoding in Compression Mode, by formatting desired FFmpeg Parameters as this parameter's attributes. All supported parameters and encoders for compression mode discussed below:
 
 
-!!! warning "Read FFmpeg Docs"
-
-    Kindly read [**FFmpeg Docs**](https://ffmpeg.org/documentation.html) carefully, before passing any values to `output_param` dictionary parameter. Wrong values may result in undesired Errors or no output at all.
+!!! danger "Kindly read [**FFmpeg Docs**](https://ffmpeg.org/documentation.html) carefully, before passing any values to `output_param` dictionary parameter. Wrong values may result in undesired Errors or no output at all."
 
 
 **Data-Type:** Dictionary
@@ -110,6 +108,8 @@ This parameter allows us to exploit almost all FFmpeg supported parameters effor
 ### Supported Parameters
 
 * **FFmpeg Parameters:** All parameters based on selected [encoder](#supported-encoders) in use, are supported, and can be passed as dictionary attributes in `output_param`. For example, for using `libx264 encoder` to produce a lossless output video, we can pass required FFmpeg parameters as dictionary attributes, as follows:
+
+    !!! warning "**DO NOT** provide additional video-source with `-i` FFmpeg parameter in `output_params`, otherwise it will interfere with frame you input later, and it will break things!"
 
     !!! tip "Kindly check [H.264 docs ➶](https://trac.ffmpeg.org/wiki/Encode/H.264) and other [FFmpeg Docs ➶](https://ffmpeg.org/documentation.html) for more information on these parameters"
 
@@ -138,6 +138,11 @@ This parameter allows us to exploit almost all FFmpeg supported parameters effor
     
         ```python
         output_params = {"-output_dimensions": (1280,720)} #to produce a 1280x720 resolution/scale output video
+        ```
+    * **`-clones`** _(list)_: sets the special FFmpeg parameters that are repeated more than once in the command _(For more info., see [this issue](https://github.com/abhiTronix/vidgear/issues/141))_ as **list** only. Its usage is as follows: 
+
+        ```python
+        output_params = {"-clones": ['-map', '0:v:0', '-map', '1:a?']}
         ```
 
 ### Supported Encoders

--- a/docs/gears/writegear/compression/usage.md
+++ b/docs/gears/writegear/compression/usage.md
@@ -29,6 +29,8 @@ limitations under the License.
 
     * **DO NOT** feed frames with different dimensions or channels to WriteGear, otherwise WriteGear will exit with `ValueError`.
 
+    * **DO NOT** provide additional video-source with `-i` FFmpeg parameter in [`output_params`](../params/#output_params), otherwise it will interfere with frame you input later, and it will break things!
+
     * Heavy resolution multimedia files take time to render which can last up to _~.1-to-1 seconds_. Kindly wait till the WriteGear API terminates itself, and **DO NOT** try to kill the process instead.
 
     * Always use `writer.close()` at the very end of the main code. **NEVER USE IT INBETWEEN CODE** to avoid undesired behavior.

--- a/vidgear/gears/helper.py
+++ b/vidgear/gears/helper.py
@@ -206,8 +206,14 @@ def dict2Args(param_dict):
     """
     args = []
     for key in param_dict.keys():
-        args.append(key)
-        args.append(param_dict[key])
+        if key in ["-clones"]:
+            if isinstance(param_dict[key], list):
+                args.extend(param_dict[key])
+            else:
+                logger.warning("Invalid datatype clones:`{}` skipped!".format(param_dict[key]))
+        else:
+            args.append(key)
+            args.append(param_dict[key])
     return args
 
 

--- a/vidgear/gears/netgear.py
+++ b/vidgear/gears/netgear.py
@@ -183,7 +183,7 @@ class NetGear:
 
         # define frame-compression handler
         self.__compression = (
-            ".jpg" if not (address is None) else ""
+            ".jpg" if not (address is None) else None
         )  # disabled by default for local connections
         self.__compression_params = (
             cv2.IMREAD_COLOR
@@ -302,11 +302,15 @@ class NetGear:
 
             elif (
                 key == "compression_format"
-                and isinstance(value, str)
-                and value.lower().strip() in [".jpg", ".jpeg", ".bmp", ".png"]
             ):
-                # assign frame-compression encoding value
-                self.__compression = value.lower().strip()
+            	if isinstance(value, str) and value.lower().strip() in [".jpg", ".jpeg", ".bmp", ".png"]
+                	# assign frame-compression encoding value
+                	self.__compression = value.lower().strip()
+                else:
+                	logger.warning(
+                        "Incorrect encoding format: `{}` skipped. Disabling Frame-Compression!".format(value)
+                    )
+                	self.__compression = None
             elif key == "compression_param":
                 # assign encoding/decoding params/flags for frame-compression if valid
                 if receive_mode and isinstance(value, int):
@@ -330,7 +334,7 @@ class NetGear:
                         ][0]
                 else:
                     logger.warning(
-                        "Invalid compression parameters: {} skipped!".format(value)
+                        "Invalid compression parameters: {} skipped.".format(value)
                     )
 
             # assign maximum retries in synchronous patterns
@@ -442,7 +446,7 @@ class NetGear:
         # handle frame compression on return data
         if (
             (self.__bi_mode or self.__multiclient_mode)
-            and self.__compression
+            and not(self.__compression is None)
             and self.__ex_compression_params is None
         ):
             # define exclusive compression params
@@ -634,9 +638,9 @@ class NetGear:
                         (protocol + "://" + str(address) + ":" + str(port)), pattern
                     )
                 )
-                if self.__compression:
+                if not(self.__compression is None):
                     logger.debug(
-                        "Optimized `{}` Frame Compression is enabled with decoding flag:`{}` for this connection.".format(
+                        "Optimized `{}` Frame-Compression is enabled with decoding flag:`{}` for this connection.".format(
                             self.__compression, self.__compression_params
                         )
                     )
@@ -812,9 +816,9 @@ class NetGear:
                         (protocol + "://" + str(address) + ":" + str(port)), pattern
                     )
                 )
-                if self.__compression:
+                if not(self.__compression is None):
                     logger.debug(
-                        "Optimized `{}` Frame Compression is enabled with encoding params:`{}` for this connection.".format(
+                        "Optimized `{}` Frame-Compression is enabled with encoding params:`{}` for this connection.".format(
                             self.__compression, self.__compression_params
                         )
                     )
@@ -945,7 +949,7 @@ class NetGear:
                             )
 
                         # handle encoding
-                        if self.__compression:
+                        if not(self.__compression is None):
                             retval, return_data = cv2.imencode(
                                 self.__compression,
                                 return_data,
@@ -1016,7 +1020,7 @@ class NetGear:
             frame = frame_buffer.reshape(msg_json["shape"])
 
             # check if encoding was enabled
-            if msg_json["compression"]:
+            if msg_json["compression"] and not(self.__compression is None):
                 frame = cv2.imdecode(frame, self.__compression_params)
                 # check if valid frame returned
                 if frame is None:
@@ -1123,7 +1127,7 @@ class NetGear:
             frame = np.ascontiguousarray(frame, dtype=frame.dtype)
 
         # handle encoding
-        if self.__compression:
+        if not(self.__compression is None):
             retval, frame = cv2.imencode(
                 self.__compression, frame, self.__compression_params
             )
@@ -1142,7 +1146,7 @@ class NetGear:
             # prepare the exclusive json dict and assign values with unique port
             msg_dict = dict(
                 terminate_flag=exit_flag,
-                compression=str(self.__compression),
+                compression=str(self.__compression) if not(self.__compression is None) else '',
                 port=self.__port,
                 pattern=str(self.__pattern),
                 message=message,
@@ -1153,7 +1157,7 @@ class NetGear:
             # otherwise prepare normal json dict and assign values
             msg_dict = dict(
                 terminate_flag=exit_flag,
-                compression=str(self.__compression),
+                compression=str(self.__compression) if not(self.__compression is None) else '',
                 message=message,
                 pattern=str(self.__pattern),
                 dtype=str(frame.dtype),

--- a/vidgear/gears/netgear.py
+++ b/vidgear/gears/netgear.py
@@ -300,17 +300,22 @@ class NetGear:
                         )
                     )
 
-            elif (
-                key == "compression_format"
-            ):
-            	if isinstance(value, str) and value.lower().strip() in [".jpg", ".jpeg", ".bmp", ".png"]
-                	# assign frame-compression encoding value
-                	self.__compression = value.lower().strip()
+            elif key == "compression_format":
+                if isinstance(value, str) and value.lower().strip() in [
+                    ".jpg",
+                    ".jpeg",
+                    ".bmp",
+                    ".png",
+                ]:
+                    # assign frame-compression encoding value
+                    self.__compression = value.lower().strip()
                 else:
-                	logger.warning(
-                        "Incorrect encoding format: `{}` skipped. Disabling Frame-Compression!".format(value)
+                    logger.warning(
+                        "Incorrect encoding format: `{}` skipped. Disabling Frame-Compression!".format(
+                            value
+                        )
                     )
-                	self.__compression = None
+                    self.__compression = None
             elif key == "compression_param":
                 # assign encoding/decoding params/flags for frame-compression if valid
                 if receive_mode and isinstance(value, int):
@@ -446,7 +451,7 @@ class NetGear:
         # handle frame compression on return data
         if (
             (self.__bi_mode or self.__multiclient_mode)
-            and not(self.__compression is None)
+            and not (self.__compression is None)
             and self.__ex_compression_params is None
         ):
             # define exclusive compression params
@@ -638,7 +643,7 @@ class NetGear:
                         (protocol + "://" + str(address) + ":" + str(port)), pattern
                     )
                 )
-                if not(self.__compression is None):
+                if not (self.__compression is None):
                     logger.debug(
                         "Optimized `{}` Frame-Compression is enabled with decoding flag:`{}` for this connection.".format(
                             self.__compression, self.__compression_params
@@ -816,7 +821,7 @@ class NetGear:
                         (protocol + "://" + str(address) + ":" + str(port)), pattern
                     )
                 )
-                if not(self.__compression is None):
+                if not (self.__compression is None):
                     logger.debug(
                         "Optimized `{}` Frame-Compression is enabled with encoding params:`{}` for this connection.".format(
                             self.__compression, self.__compression_params
@@ -949,7 +954,7 @@ class NetGear:
                             )
 
                         # handle encoding
-                        if not(self.__compression is None):
+                        if not (self.__compression is None):
                             retval, return_data = cv2.imencode(
                                 self.__compression,
                                 return_data,
@@ -1020,7 +1025,7 @@ class NetGear:
             frame = frame_buffer.reshape(msg_json["shape"])
 
             # check if encoding was enabled
-            if msg_json["compression"] and not(self.__compression is None):
+            if msg_json["compression"] and not (self.__compression is None):
                 frame = cv2.imdecode(frame, self.__compression_params)
                 # check if valid frame returned
                 if frame is None:
@@ -1127,7 +1132,7 @@ class NetGear:
             frame = np.ascontiguousarray(frame, dtype=frame.dtype)
 
         # handle encoding
-        if not(self.__compression is None):
+        if not (self.__compression is None):
             retval, frame = cv2.imencode(
                 self.__compression, frame, self.__compression_params
             )
@@ -1146,7 +1151,9 @@ class NetGear:
             # prepare the exclusive json dict and assign values with unique port
             msg_dict = dict(
                 terminate_flag=exit_flag,
-                compression=str(self.__compression) if not(self.__compression is None) else '',
+                compression=str(self.__compression)
+                if not (self.__compression is None)
+                else "",
                 port=self.__port,
                 pattern=str(self.__pattern),
                 message=message,
@@ -1157,7 +1164,9 @@ class NetGear:
             # otherwise prepare normal json dict and assign values
             msg_dict = dict(
                 terminate_flag=exit_flag,
-                compression=str(self.__compression) if not(self.__compression is None) else '',
+                compression=str(self.__compression)
+                if not (self.__compression is None)
+                else "",
                 message=message,
                 pattern=str(self.__pattern),
                 dtype=str(frame.dtype),

--- a/vidgear/gears/writegear.py
+++ b/vidgear/gears/writegear.py
@@ -212,7 +212,7 @@ class WriteGear:
             rgb_mode (boolean): enable this flag to activate RGB mode _(i.e. specifies that incoming frames are of RGB format(instead of default BGR)_.
 
         """
-        if frame is None:  # NoneType frames will be skipped
+        if frame is None:  # None-Type frames will be skipped
             return
 
         # get height, width and number of channels of current frame

--- a/vidgear/gears/writegear.py
+++ b/vidgear/gears/writegear.py
@@ -120,9 +120,16 @@ class WriteGear:
             _filename
         )  # extract file base path for debugging ahead
 
+        # handle user defined output dimensions(must be a tuple or list)
+        if output_params and "-output_dimensions" in output_params:
+            self.__output_dimensions = output_params[
+                "-output_dimensions"
+            ]  # assign special parameter to global variable
+            del output_params["-output_dimensions"]  # clean
+
         # cleans and reformat output parameters
         self.__output_parameters = {
-            str(k).strip(): v.strip() if isinstance(v, str) else v
+            str(k).strip(): str(v).strip() if not isinstance(v, list) else v
             for k, v in output_params.items()
         }
 
@@ -139,13 +146,6 @@ class WriteGear:
                 logger.debug(self.__output_parameters)
 
             if self.__output_parameters:
-
-                # handle user defined output dimensions(must be a tuple or list)
-                if "-output_dimensions" in self.__output_parameters:
-                    self.__output_dimensions = output_params[
-                        "-output_dimensions"
-                    ]  # assign special parameter to global variable
-                    del output_params["-output_dimensions"]  # clean
 
                 if "-ffmpeg_download_path" in self.__output_parameters:
                     ffmpeg_download_path_ += self.__output_parameters[

--- a/vidgear/gears/writegear.py
+++ b/vidgear/gears/writegear.py
@@ -120,21 +120,17 @@ class WriteGear:
             _filename
         )  # extract file base path for debugging ahead
 
-        if output_params:
-            # handle user defined output dimensions(must be a tuple or list)
-            if output_params and "-output_dimensions" in output_params:
-                self.__output_dimensions = output_params[
-                    "-output_dimensions"
-                ]  # assign special parameter to global variable
-                del output_params["-output_dimensions"]  # clean
-
-            # cleans and reformat output parameters
-            self.__output_parameters = {
-                str(k).strip().lower(): str(v).strip() for k, v in output_params.items()
-            }
+        # cleans and reformat output parameters
+        self.__output_parameters = {
+            str(k).strip(): v.strip() if isinstance(v, str) else v
+            for k, v in output_params.items()
+        }
 
         # handles FFmpeg binaries validity tests
         if self.__compression:
+
+            # handles where to save the downloaded FFmpeg Static Binaries on Windows(if specified)
+            ffmpeg_download_path_ = ""
 
             if self.__logging:
                 logger.debug(
@@ -142,26 +138,27 @@ class WriteGear:
                 )
                 logger.debug(self.__output_parameters)
 
-            # handles where to save the downloaded FFmpeg Static Binaries on Windows(if specified)
-            ffmpeg_download_path_ = ""
-            if (
-                self.__output_parameters
-                and "-ffmpeg_download_path" in self.__output_parameters
-            ):
-                ffmpeg_download_path_ += self.__output_parameters[
-                    "-ffmpeg_download_path"
-                ]
-                del self.__output_parameters["-ffmpeg_download_path"]  # clean
+            if self.__output_parameters:
 
-            # handle input framerate if specified
-            if (
-                self.__output_parameters
-                and "-input_framerate" in self.__output_parameters
-            ):
-                self.__inputframerate = float(
-                    self.__output_parameters["-input_framerate"]
-                )
-                del self.__output_parameters["-input_framerate"]  # clean
+                # handle user defined output dimensions(must be a tuple or list)
+                if "-output_dimensions" in self.__output_parameters:
+                    self.__output_dimensions = output_params[
+                        "-output_dimensions"
+                    ]  # assign special parameter to global variable
+                    del output_params["-output_dimensions"]  # clean
+
+                if "-ffmpeg_download_path" in self.__output_parameters:
+                    ffmpeg_download_path_ += self.__output_parameters[
+                        "-ffmpeg_download_path"
+                    ]
+                    del self.__output_parameters["-ffmpeg_download_path"]  # clean
+
+                # handle input framerate if specified
+                if "-input_framerate" in self.__output_parameters:
+                    self.__inputframerate = float(
+                        self.__output_parameters["-input_framerate"]
+                    )
+                    del self.__output_parameters["-input_framerate"]  # clean
 
             # validate the FFmpeg path/binaries and returns valid FFmpeg file executable location(also downloads static binaries on windows)
             actual_command = get_valid_ffmpeg_path(

--- a/vidgear/gears/writegear.py
+++ b/vidgear/gears/writegear.py
@@ -143,7 +143,7 @@ class WriteGear:
                 logger.debug(
                     "Compression Mode is enabled therefore checking for valid FFmpeg executables."
                 )
-                logger.debug(self.__output_parameters)
+                logger.debug("Output_params Dict: {}".format(self.__output_parameters))
 
             if self.__output_parameters:
 

--- a/vidgear/tests/network_tests/test_netgear.py
+++ b/vidgear/tests/network_tests/test_netgear.py
@@ -198,8 +198,11 @@ def test_patterns(pattern):
 @pytest.mark.parametrize(
     "options_client",
     [
-        {"compression_param": cv2.IMREAD_UNCHANGED},
-        {"compression_param": [cv2.IMWRITE_JPEG_QUALITY, 80]},
+        {"compression_format": None, "compression_param": cv2.IMREAD_UNCHANGED},
+        {
+            "compression_format": ".jpg",
+            "compression_param": [cv2.IMWRITE_JPEG_QUALITY, 80],
+        },
     ],
 )
 def test_compression(options_client):

--- a/vidgear/tests/test_helper.py
+++ b/vidgear/tests/test_helper.py
@@ -31,12 +31,14 @@ import requests
 from os.path import expanduser
 from vidgear.gears.asyncio.helper import generate_webdata, validate_webdata
 from vidgear.gears.helper import (
-    check_output, reducer,
+    check_output,
+    reducer,
     download_ffmpeg_binaries,
     generate_auth_certificates,
     get_valid_ffmpeg_path,
     logger_handler,
     validate_ffmpeg,
+    dict2Args,
 )
 
 # define test logger
@@ -90,6 +92,38 @@ def test_ffmpeg_static_installation():
         subindent = " " * 4 * (level + 1)
         for f in files:
             logger.debug("{}{}".format(subindent, f))
+
+
+test_data = [
+    {"-thread_queue_size": "512", "-f": "alsa", "-clones": 24},
+    {
+        "-thread_queue_size": "512",
+        "-f": "alsa",
+        "-clones": ["-map", "0:v:0", "-map", "1:a?"],
+        "-ac": "1",
+        "-ar": "48000",
+        "-i": "plughw:CARD=CAMERA,DEV=0",
+    },
+    {
+        "-thread_queue_size": "512",
+        "-f": "alsa",
+        "-ac": "1",
+        "-ar": "48000",
+        "-i": "plughw:CARD=CAMERA,DEV=0",
+    },
+]
+
+
+@pytest.mark.parametrize("dictionary", test_data)
+def test_dict2Args(dictionary):
+    """
+    Testing dict2Args helper function. 
+    """
+    result = dict2Args(dictionary)
+    if result and isinstance(result, list):
+        logger.debug("dict2Args converted Arguments are: {}".format(result))
+    else:
+        pytest.fail(str(e))
 
 
 test_data = [

--- a/vidgear/tests/test_helper.py
+++ b/vidgear/tests/test_helper.py
@@ -123,7 +123,7 @@ def test_dict2Args(dictionary):
     if result and isinstance(result, list):
         logger.debug("dict2Args converted Arguments are: {}".format(result))
     else:
-        pytest.fail(str(e))
+        pytest.fail("Failed to complete this test!")
 
 
 test_data = [


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->

## Description

This PR add support for **`-clones`** list attribute, which sets the special FFmpeg arguments that are repeated more than once in the terminal command. User can now format repeating duplicate parameter as list and pass with this attribute of `output_param` dictionary parameter in WriteGear API.

### Highlights
- Added new `-clones` attribute in `output_params` parameter for handing this behavior.
- Implemented support to pass arguments as list for this attribute, and maintaining the exact order it was specified.
- Added new helper.py test for `dict2Args` function for debugging this behavior.
- Updated docs accordingly.


### Requirements / Checklist

<!--- By pushing this PR you acknowledge the following: Put an `x` in all the boxes that apply(important): -->

- [x] I have read the [PR Guidelines](https://abhitronix.github.io/contribution/PR/).
- [x] I have read the [Documentation](https://abhitronix.github.io/vidgear).
- [x] Updated the source-code documentation accordingly(if required).


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#141

### Context
<!--- Why is this change required? What problem does it solve? -->
This PR solves special case where FFmpeg arguments that are repeated more than once in the terminal command.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply(important): -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Testcode:

**Merging audio with video:**

```python
# import required libraries
from vidgear.gears import VideoGear
from vidgear.gears import WriteGear
import cv2
import time

#Open input video stream
stream = VideoGear(source='input-video.mp4').start()

#set input audio stream path 
input_audio = "input-audio.aac"

#define your parameters
output_params = {'-input_framerate':stream.framerate, `-i`: input_audio , '-acodec':'libmp3lame', '-q:a': '50', '-c:v','copy', '-clones':[-map, 0:v, -map, 1:a]} #output framerate must match source framerate

# Define writer with defined parameters and suitable output filename for e.g. `Output.mp4`
writer = WriteGear(output_filename = 'Output.mp4', logging = True, **output_params)

# loop over
while True:

    # read frames from stream
    frame = stream.read()

    # check for frame if Nonetype
    if frame is None:
        break


    # {do something with the frame here}


    # write frame to writer
    writer.write(frame)

    # Show output window
    cv2.imshow("Output Frame", frame)

    # check for 'q' key if pressed
    key = cv2.waitKey(1) & 0xFF
    if key == ord("q"):
        break

# close output window
cv2.destroyAllWindows()

# safely close video stream
stream.stop()

# safely close writer
writer.close()


```
<!--- Provide screenshots where appropriate -->