### PR TITLE
✨ NetGear: New additional colorspace frames support to Frame Compression

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ pr:
   - testing
 
 pool:
-  vmImage: 'macOS-10.14'
+  vmImage: 'macOS-latest'
 
 strategy:
   matrix:

--- a/docs/gears/netgear/params.md
+++ b/docs/gears/netgear/params.md
@@ -159,11 +159,11 @@ This parameter provides the flexibility to alter various NetGear API's internal 
 
     * **`overwrite_cert`** (_boolean_) : In Secure Mode, This internal attribute decides whether to overwrite existing Public+Secret Keypair/Certificates or not, ==at the Server-end only==. More information can be found [here ➶](../advanced/secure_mode/#supported-attributes)
 
-    * **`jpeg_compression`**(_bool_): This internal attribute can be used to activate(if True)/deactivate(if False) Frame Compression. Its default value is also `True`. More information can be found [here ➶](../advanced/compression/#supported-attributes)
+    * **`jpeg_compression`**(_bool/str_): This internal attribute is used to activate(if `True`)/deactivate(if `False`) JPEG Frame Compression as well as to specify incoming frames colorspace with compression. By default colorspace is `BGR` and compression is enabled(`True`). More information can be found [here ➶](../advanced/compression/#supported-attributes)
 
-    * **`jpeg_compression_quality`**(_int/float_): This internal attribute controls the JPEG quantization factor. Its value varies from `10` to `100` (the higher is the better quality but performance will be lower). Its default value is `90`. More information can be found [here ➶](../advanced/compression/#supported-attributes)
+    * **`jpeg_compression_quality`**(_int/float_): This internal attribute controls the JPEG quantization factor in JPEG Frame Compression. Its value varies from `10` to `100` (the higher is the better quality but performance will be lower). Its default value is `90`. More information can be found [here ➶](../advanced/compression/#supported-attributes)
 
-    * **`jpeg_compression_fastdct`**(_bool_): This internal attributee if True, use fastest DCT method that speeds up decoding by 4-5% for a minor loss in quality. Its default value is also `True`. More information can be found [here ➶](../advanced/compression/#supported-attributes)
+    * **`jpeg_compression_fastdct`**(_bool_): This internal attributee if True, use fastest DCT method that speeds up decoding by 4-5% for a minor loss in quality in JPEG Frame Compression. Its default value is also `True`. More information can be found [here ➶](../advanced/compression/#supported-attributes)
 
     * **`jpeg_compression_fastupsample`**(_bool_): This internal attribute if True, use fastest color upsampling method. Its default value is `False`. More information can be found [here ➶](../advanced/compression/#supported-attributes)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,9 +24,6 @@ repo_name: abhiTronix/vidgear
 repo_url: https://github.com/abhiTronix/vidgear
 edit_uri: ""
 
-# Google analytics
-google_analytics: ['UA-131929464-1', 'abhitronix.github.io']
-
 # Copyright
 copyright: Copyright &copy; 2019 - 2021 Abhishek Thakur(@abhiTronix)
 
@@ -99,6 +96,9 @@ extra:
   manifest: site.webmanifest
   version:
     provider: mike
+  analytics: # Google analytics
+    provider: google
+    property: UA-131929464-1 
 
 
 extra_css:

--- a/vidgear/gears/asyncio/__main__.py
+++ b/vidgear/gears/asyncio/__main__.py
@@ -191,6 +191,5 @@ if __name__ == "__main__":
     # run this object on Uvicorn server
     uvicorn.run(web(), host=args["ipaddress"], port=args["port"])
 
-    if args["mode"] == "mjpeg":
-        # close app safely
-        web.shutdown()
+    # close app safely
+    web.shutdown()

--- a/vidgear/gears/netgear.py
+++ b/vidgear/gears/netgear.py
@@ -1067,6 +1067,9 @@ class NetGear:
                         # handle jpeg-compression encoding
                         if self.__jpeg_compression:
                             if self.__jpeg_compression_colorspace == "GRAY":
+                                if return_data.ndim == 2:
+                                    # patch for https://gitlab.com/jfolz/simplejpeg/-/issues/11
+                                    return_data = return_data[:, :, np.newaxis]
                                 return_data = simplejpeg.encode_jpeg(
                                     return_data,
                                     quality=self.__jpeg_compression_quality,
@@ -1258,6 +1261,9 @@ class NetGear:
         # handle JPEG compression encoding
         if self.__jpeg_compression:
             if self.__jpeg_compression_colorspace == "GRAY":
+                if frame.ndim == 2:
+                    # patch for https://gitlab.com/jfolz/simplejpeg/-/issues/11
+                    frame = frame[:, :, np.newaxis]
                 frame = simplejpeg.encode_jpeg(
                     frame,
                     quality=self.__jpeg_compression_quality,

--- a/vidgear/tests/network_tests/test_netgear.py
+++ b/vidgear/tests/network_tests/test_netgear.py
@@ -314,7 +314,10 @@ def test_secure_mode(pattern, security_mech, custom_cert_location, overwrite_cer
         ),
         (
             1,
-            (np.random.random(size=(480, 640, 3)) * 255).astype(np.uint8),
+            {
+                1: "apple",
+                2: "cat",
+            },
             {
                 "bidirectional_mode": True,
                 "jpeg_compression": False,
@@ -325,10 +328,7 @@ def test_secure_mode(pattern, security_mech, custom_cert_location, overwrite_cer
         ),
         (
             1,
-            {
-                1: "apple",
-                2: "cat",
-            },
+            (np.random.random(size=(480, 640, 3)) * 255).astype(np.uint8),
             {"bidirectional_mode": True, "jpeg_compression": "GRAY"},
         ),
         (

--- a/vidgear/tests/network_tests/test_netgear.py
+++ b/vidgear/tests/network_tests/test_netgear.py
@@ -20,6 +20,7 @@ limitations under the License.
 # import the necessary packages
 
 import os
+import platform
 import queue
 import cv2
 import numpy as np
@@ -153,7 +154,7 @@ def test_patterns(pattern):
         assert not (frame_server is None)
         # send frame over network
         server.send(frame_server)
-        frame_client = client.recv()
+        frame_client = client.recv(return_data=[1, 2, 3] if pattern == 2 else None)
         # check if received frame exactly matches input frame
         assert np.array_equal(frame_server, frame_client)
     except Exception as e:
@@ -246,7 +247,14 @@ def test_compression(options_server):
 test_data_class = [
     (0, 1, tempfile.gettempdir(), True),
     (0, 1, ["invalid"], True),
-    (1, 1, "unknown://invalid.com/", False),
+    (
+        1,
+        2,
+        os.path.abspath(os.sep)
+        if platform.system() == "Linux"
+        else "unknown://invalid.com/",
+        False,
+    ),
 ]
 
 
@@ -350,24 +358,29 @@ def test_bidirectional_mode(pattern, target_data, options):
     server = None
     client = None
     try:
-        logger.debug("Given Input Data: {}".format(target_data))
+        logger.debug(
+            "Given Input Data: {}".format(
+                target_data if not isinstance(target_data, np.ndarray) else "IMAGE"
+            )
+        )
         # open stream
         options_gear = {"THREAD_TIMEOUT": 60}
+        # change colorspace
         colorspace = (
             "COLOR_BGR2GRAY"
             if isinstance(options["jpeg_compression"], str)
             and options["jpeg_compression"].strip().upper() == "GRAY"
             else None
         )
+        if colorspace == "COLOR_BGR2GRAY" and isinstance(target_data, np.ndarray):
+            target_data = cv2.cvtColor(target_data, cv2.COLOR_BGR2GRAY)
+
         stream = VideoGear(
             source=return_testvideo_path(), colorspace=colorspace, **options_gear
         ).start()
         # define params
-        client = NetGear(pattern=pattern, receive_mode=True, **options)
-        server = NetGear(pattern=pattern, **options)
-        # get frame from stream
-        frame_server = stream.read()
-        assert not (frame_server is None)
+        client = NetGear(pattern=pattern, receive_mode=True, logging=True, **options)
+        server = NetGear(pattern=pattern, logging=True, **options)
         # check if target data is numpy ndarray
         if isinstance(target_data, np.ndarray):
             # sent frame and data from server to client
@@ -375,11 +388,13 @@ def test_bidirectional_mode(pattern, target_data, options):
             # client receives the data and frame and send its data
             server_data, frame_client = client.recv(return_data=target_data)
             # server receives the data and cycle continues
-            client_data = server.send(target_data, message=target_data)
-            # logger.debug data received at client-end and server-end
-            logger.debug("Data received at Server-end: {}".format(frame_client))
-            logger.debug("Data received at Client-end: {}".format(client_data))
+            client_data = server.send(target_data)
+            # test if recieved successfully
+            assert not (client_data is None), "Test Failed!"
         else:
+            # get frame from stream
+            frame_server = stream.read()
+            assert not (frame_server is None)
             # sent frame and data from server to client
             server.send(frame_server, message=target_data)
             # client receives the data and frame and send its data
@@ -609,13 +624,13 @@ def test_multiclient_mode(pattern):
             "ssh_tunnel_pwd": "xyz",
             "ssh_tunnel_keyfile": "ok.txt",
         },
-        {"max_retries": 2, "request_timeout": 2, "multiclient_mode": True},
-        {"max_retries": 2, "request_timeout": 2, "multiserver_mode": True},
+        {"max_retries": 2, "request_timeout": 4, "multiclient_mode": True},
+        {"max_retries": 2, "request_timeout": -1, "multiserver_mode": True},
     ],
 )
 def test_client_reliablity(options):
     """
-    Testing validation function of WebGear API
+    Testing validation function of NetGear API
     """
     client = None
     frame_client = None
@@ -671,7 +686,7 @@ def test_client_reliablity(options):
 )
 def test_server_reliablity(options):
     """
-    Testing validation function of WebGear API
+    Testing validation function of NetGear API
     """
     server = None
     stream = None
@@ -706,3 +721,25 @@ def test_server_reliablity(options):
             stream.release()
         if not (server is None):
             server.close()
+
+
+@pytest.mark.parametrize(
+    "server_ports, client_ports, options",
+    [
+        (0, 5555, {"multiserver_mode": True}),
+        (5555, 0, {"multiclient_mode": True}),
+    ],
+)
+@pytest.mark.xfail(raises=ValueError)
+def test_ports(server_ports, client_ports, options):
+    """
+    Test made to fail on wrong port values
+    """
+    if server_ports:
+        server = NetGear(pattern=1, port=server_ports, logging=True, **options)
+        server.close()
+    else:
+        client = NetGear(
+            port=client_ports, pattern=1, receive_mode=True, logging=True, **options
+        )
+        client.close()

--- a/vidgear/tests/network_tests/test_netgear.py
+++ b/vidgear/tests/network_tests/test_netgear.py
@@ -172,28 +172,30 @@ def test_patterns(pattern):
 
 
 @pytest.mark.parametrize(
-    "options_client",
+    "options_server",
     [
-        {"compression_format": None, "compression_param": cv2.IMREAD_UNCHANGED},
         {
-            "compression_format": ".jpg",
-            "compression_param": [cv2.IMWRITE_JPEG_QUALITY, 80],
+            "jpeg_compression": "invalid",
+            "jpeg_compression_quality": 5,
+        },
+        {
+            "jpeg_compression": " gray  ",
+            "jpeg_compression_quality": 50,
+            "jpeg_compression_fastdct": True,
+            "jpeg_compression_fastupsample": True,
+        },
+        {
+            "jpeg_compression": True,
+            "jpeg_compression_quality": 55.55,
+            "jpeg_compression_fastdct": True,
+            "jpeg_compression_fastupsample": True,
         },
     ],
 )
-def test_compression(options_client):
+def test_compression(options_server):
     """
     Testing NetGear's real-time frame compression capabilities
     """
-    options = {
-        "compression_format": ".jpg",
-        "compression_param": [
-            cv2.IMWRITE_JPEG_QUALITY,
-            20,
-            cv2.IMWRITE_JPEG_OPTIMIZE,
-            True,
-        ],
-    }  # JPEG compression
     # initialize
     stream = None
     server = None
@@ -201,9 +203,17 @@ def test_compression(options_client):
     try:
         # open streams
         options_gear = {"THREAD_TIMEOUT": 60}
-        stream = VideoGear(source=return_testvideo_path(), **options_gear).start()
-        client = NetGear(pattern=0, receive_mode=True, logging=True, **options_client)
-        server = NetGear(pattern=0, logging=True, **options)
+        colorspace = (
+            "COLOR_BGR2GRAY"
+            if isinstance(options_server["jpeg_compression"], str)
+            and options_server["jpeg_compression"].strip().upper() == "GRAY"
+            else None
+        )
+        stream = VideoGear(
+            source=return_testvideo_path(), colorspace=colorspace, **options_gear
+        ).start()
+        client = NetGear(pattern=0, receive_mode=True, logging=True)
+        server = NetGear(pattern=0, logging=True, **options_server)
         # send over network
         while True:
             frame_server = stream.read()
@@ -211,6 +221,13 @@ def test_compression(options_client):
                 break
             server.send(frame_server)
             frame_client = client.recv()
+            if (
+                isinstance(options_server["jpeg_compression"], str)
+                and options_server["jpeg_compression"].strip().upper() == "GRAY"
+            ):
+                assert (
+                    frame_server.ndim == frame_client.ndim
+                ), "Grayscale frame Test Failed!"
     except Exception as e:
         if isinstance(e, (ZMQError, ValueError, RuntimeError, queue.Empty)):
             logger.exception(str(e))
@@ -287,26 +304,40 @@ def test_secure_mode(pattern, security_mech, custom_cert_location, overwrite_cer
 @pytest.mark.parametrize(
     "pattern, target_data, options",
     [
-        (0, [1, "string", ["list"]], {"bidirectional_mode": True}),
+        (
+            0,
+            [1, "string", ["list"]],
+            {
+                "bidirectional_mode": True,
+                "jpeg_compression": ["invalid"],
+            },
+        ),
         (
             1,
             (np.random.random(size=(480, 640, 3)) * 255).astype(np.uint8),
             {
                 "bidirectional_mode": True,
-                "jpeg_compression_quality": 55.0,
-                "jpeg_compression_fastdct": True,
-                "jpeg_compression_fastupsample": True,
+                "jpeg_compression": False,
+                "jpeg_compression_quality": 55,
+                "jpeg_compression_fastdct": False,
+                "jpeg_compression_fastupsample": False,
             },
         ),
         (
-            2,
+            1,
             {
-                "jpeg_compression": False,
                 1: "apple",
                 2: "cat",
-                "jpeg_compression_quality": 5,
             },
-            {"bidirectional_mode": True},
+            {"bidirectional_mode": True, "jpeg_compression": "GRAY"},
+        ),
+        (
+            2,
+            (np.random.random(size=(480, 640, 3)) * 255).astype(np.uint8),
+            {
+                "bidirectional_mode": True,
+                "jpeg_compression": True,
+            },
         ),
     ],
 )
@@ -322,7 +353,15 @@ def test_bidirectional_mode(pattern, target_data, options):
         logger.debug("Given Input Data: {}".format(target_data))
         # open stream
         options_gear = {"THREAD_TIMEOUT": 60}
-        stream = VideoGear(source=return_testvideo_path(), **options_gear).start()
+        colorspace = (
+            "COLOR_BGR2GRAY"
+            if isinstance(options["jpeg_compression"], str)
+            and options["jpeg_compression"].strip().upper() == "GRAY"
+            else None
+        )
+        stream = VideoGear(
+            source=return_testvideo_path(), colorspace=colorspace, **options_gear
+        ).start()
         # define params
         client = NetGear(pattern=pattern, receive_mode=True, **options)
         server = NetGear(pattern=pattern, **options)
@@ -340,8 +379,6 @@ def test_bidirectional_mode(pattern, target_data, options):
             # logger.debug data received at client-end and server-end
             logger.debug("Data received at Server-end: {}".format(frame_client))
             logger.debug("Data received at Client-end: {}".format(client_data))
-            if "jpeg_compression" in options and options["jpeg_compression"] == False:
-                assert np.array_equal(client_data, frame_client)
         else:
             # sent frame and data from server to client
             server.send(frame_server, message=target_data)
@@ -350,7 +387,7 @@ def test_bidirectional_mode(pattern, target_data, options):
             # server receives the data and cycle continues
             client_data = server.send(frame_server, message=target_data)
             # check if received frame exactly matches input frame
-            if "jpeg_compression" in options and options["jpeg_compression"] == False:
+            if not options["jpeg_compression"] in [True, "GRAY", ["invalid"]]:
                 assert np.array_equal(frame_server, frame_client)
             # logger.debug data received at client-end and server-end
             logger.debug("Data received at Server-end: {}".format(server_data))


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->

## Description

NetGear currently only supports `BGR` colorspace frames as input with its [Frame Compression](https://abhitronix.github.io/vidgear/v0.2.2-dev/gears/netgear/advanced/compression/) but rejects any other colorspaces(always defaults to `BGR`). This PR will add support for additional colorspaces that can be specified manually.



### Requirements / Checklist

<!--- By pushing this PR you acknowledge the following: Put an `x` in all the boxes that apply(important): -->

- [x] I have read the [PR Guidelines](https://abhitronix.github.io/vidgear/contribution/PR/#submitting-pull-requestpr-guidelines).
- [x] I have read the [Documentation](https://abhitronix.github.io/vidgear).
- [x] I have updated the documentation accordingly(if required).


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#230 

### Context
<!--- Why is this change required? What problem does it solve? -->
NetGear API currently only supports `BGR` colorspace and also doesn't let users to manually alter it when its Frame Compression mode is enabled. But under the hood, backend `simplejpeg` library do support specifying input frames colorspace with its `encode_jpeg` and `decode_jpeg` methods. Thereby, This PR will track merge of this update that allow users to directly control input frames colorspace. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in the box that apply(important): -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Screenshots (if available):
<!--- Provide screenshots where appropriate -->
None