### PR TITLE
✨ WriteGear: Add support for GStreamer pipeline in Non-Compression mode

### DIFF
--- a/docs/gears/camgear/params.md
+++ b/docs/gears/camgear/params.md
@@ -75,7 +75,7 @@ Its valid input can be one of the following:
 
     !!! warning "Requirements for GStreamer Pipelining"
 
-        Successful GStreamer Pipelining needs your OpenCV to be built with GStreamer support. Checkout [this FAQ](../../../help/camgear_faqs/#how-to-compile-opencv-with-gstreamer-support) for compiling OpenCV with GStreamer support.
+        GStreamer Pipelining in WriteGear your OpenCV to be built with GStreamer support. Checkout [this FAQ](../../../help/camgear_faqs/#how-to-compile-opencv-with-gstreamer-support) for compiling OpenCV with GStreamer support.
 
         Thereby, You can easily check GStreamer support by running `print(cv2.getBuildInformation())` python command and see if output contains something similar as follows:
 

--- a/docs/gears/writegear/non_compression/params.md
+++ b/docs/gears/writegear/non_compression/params.md
@@ -41,13 +41,33 @@ Its valid input can be one of the following:
 * **Path to directory**: Valid path of the directory to save the output video file. In this case, WriteGear API will automatically assign a unique filename (_with a default extension i.e.`.mp4`_) as follows:
 
     ```python
-    writer = WriteGear(output_filename = '/home/foo/foo1') #Define writer 
+    writer = WriteGear(output_filename = '/home/foo/foo1', compression_mode=False) # Define writer 
     ```
 
 * **Filename** _(with/without path)_: Valid filename(_with valid extension_) of the output video file. In case filename is provided without path, then current working directory will be used.
 
     ```python
-    writer = WriteGear(output_filename = 'output.mp4') #Define writer 
+    writer = WriteGear(output_filename = 'output.mp4', compression_mode=False) # Define writer 
+    ```
+
+* **GStreamer Pipeline:** 
+   
+    WriteGear API also supports GStreamer Pipeline as input to its `output_filename` parameter in Non-Compression Mode, when [GStreamer Pipeline Mode](#b-exclusive-parameters) is enabled. It can be used as follows:
+
+    !!! warning "Requirement for GStreamer Pipelining"
+
+        GStreamer Pipelining in WriteGear requires your OpenCV to be built with GStreamer support. Checkout [this FAQ](../../../../help/camgear_faqs/#how-to-compile-opencv-with-gstreamer-support) for compiling OpenCV with GStreamer support.
+
+
+    ??? new "New in v0.2.5" 
+        This feature was added in `v0.2.5`.
+
+    ```python
+    # enable GStreamer Pipeline Mode for writer
+    output_params = {"-gst_pipeline_mode": True}
+    # Define writer
+    writer = WriteGear(
+    output_filename="appsrc ! videoconvert ! avenc_mpeg4 bitrate=100000 ! mp4mux ! filesink location=foo.mp4", compression_mode=False) 
     ```
 
 &nbsp;
@@ -88,10 +108,15 @@ This parameter allows us to exploit almost all [**OpenCV's VideoWriter API**](ht
 
 **Default Value:** Its default value is `{}`.
 
+&thinsp; 
 
-### Supported Parameters
+### Supported Attributes
 
-Non-Compression Mode only gives access to a limited number of parameters, which are as follows:
+Non-Compression Mode only gives access to a limited number of Parameters through its `output_params` parameter's attributes, which are as follows:
+
+#### A. OpenCV Parameters
+
+WriteGear provides access to all available [**OpenCV's VideoWriter API**](https://docs.opencv.org/master/dd/d9e/classcv_1_1VideoWriter.html#ad59c61d8881ba2b2da22cff5487465b5) parameters in Non-Compression Mode.
 
 | Parameters | Description |
 |:-----------:|-------------|
@@ -101,6 +126,19 @@ Non-Compression Mode only gives access to a limited number of parameters, which 
 |`-color`| (optional) _If it is not zero(0), the encoder will expect and encode color frames, otherwise it will work with grayscale frames (the flag is currently supported on Windows only)_ |
 
 !!! warning "`-height` and `-width` parameter are no longer supported and are automatically derived from the input frames."
+
+#### B. Exclusive Parameters
+
+In addition to OpenCV Parameters, WriteGear API also provides few exclusive attribute, which are as follows: 
+
+* **`-gst_pipeline_mode`**: a boolean attribute to enable **GStreamer Pipeline Mode** to supports GStreamer Pipeline as input to its `output_filename` parameter in Non-Compression Mode.
+
+    !!! note "Enabling `-gst_pipeline_mode` will enforce `-backend` parameter value to `"CAP_GSTREAMER"`"
+
+    ??? new "New in v0.2.5" 
+        `-gst_pipeline_mode` attribute was added in `v0.2.5`.
+
+    !!! example "Its usage example can be found [here ➶](../usage/#using-non-compression-mode-with-gstreamer-pipeline)."
 
 
 **Usage:**
@@ -115,6 +153,8 @@ WriteGear(output_filename = 'output.mp4', **output_params)
 ```
 
 !!! example "Its usage example can be found [here ➶](../usage/#using-non-compression-mode-with-videocapture-gears)."
+
+&thinsp;
 
 ### Supported FOURCC Codecs
 

--- a/docs/gears/writegear/non_compression/usage.md
+++ b/docs/gears/writegear/non_compression/usage.md
@@ -84,10 +84,15 @@ writer.close()
 
 &nbsp; 
 
+&nbsp; 
+
 ## Using Non-Compression Mode with VideoCapture Gears
 
+In Non-Compression mode, WriteGear API provides flexible control over [**OpenCV's VideoWriter API**](https://docs.opencv.org/master/dd/d9e/classcv_1_1VideoWriter.html#ad59c61d8881ba2b2da22cff5487465b5) parameters through its `output_param` dictionary parameter by formating them as dictionary attributes. Moreover, WriteGear API can be used in conjunction with any other Gears/APIs effortlessly. 
 
-In Non-Compression mode, WriteGear API provides flexible control over [**OpenCV's VideoWriter API**](https://docs.opencv.org/master/dd/d9e/classcv_1_1VideoWriter.html#ad59c61d8881ba2b2da22cff5487465b5) parameters through its `output_param` dictionary parameter by formating them as dictionary attributes. Also, WriteGear API can be used in conjunction with any other Gear effortlessly. The complete usage example is as follows:
+!!! info "All supported attributes for `output_param` can be found  [here ➶](../params/#a-opencv-parameters)"
+
+The complete usage example is as follows:
 
 ```python
 # import required libraries
@@ -142,8 +147,10 @@ stream.stop()
 writer.close()
 ```
 
+&nbsp; 
 
-&nbsp;
+&nbsp; 
+
 
 ## Using Non-Compression Mode with OpenCV
 
@@ -184,6 +191,77 @@ while True:
 
     # Show output window
     cv2.imshow("Output Gray Frame", gray)
+
+    # check for 'q' key if pressed
+    key = cv2.waitKey(1) & 0xFF
+    if key == ord("q"):
+        break
+
+# close output window
+cv2.destroyAllWindows()
+
+# safely close video stream
+stream.release()
+
+# safely close writer
+writer.close()
+```
+
+&nbsp; 
+
+&nbsp; 
+
+
+## Using Non-Compression Mode with GStreamer Pipeline
+
+  WriteGear API's Non-Compression Mode also supports GStreamer Pipeline as input to its `output_filename` parameter, when [GStreamer Pipeline Mode](../params/#b-exclusive-parameters) is enabled. This provides flexible way to write video frames to file or network stream with controlled framerate and bitrate. The complete usage example is as follows:
+
+!!! warning "Requirement for GStreamer Pipelining"
+    GStreamer Pipelining in WriteGear requires your OpenCV to be built with GStreamer support. Checkout [this FAQ](../../../../help/camgear_faqs/#how-to-compile-opencv-with-gstreamer-support) for compiling OpenCV with GStreamer support.
+
+??? new "New in v0.2.5" 
+    This example was added in `v0.2.5`.
+
+In this example we will be constructing GStreamer pipeline to write video-frames into a file(`foo.mp4`) at 1M video-bitrate.
+
+```python
+# import required libraries
+from vidgear.gears import WriteGear
+import cv2
+
+# enable GStreamer Pipeline Mode for writer
+output_params = {"-gst_pipeline_mode": True}
+
+# open live video stream on webcam at first index(i.e. 0) device
+stream = cv2.VideoCapture(0)
+
+# gst pipeline to write to a file `foo.mp4` at 1M video-bitrate
+GSTPipeline = "appsrc ! videoconvert ! avenc_mpeg4 bitrate=100000 ! mp4mux ! filesink location={}".format(
+    "foo.mp4"
+)
+
+# Define writer with defined parameters and with our Gstreamer pipeline
+writer = WriteGear(
+    output_filename=GSTPipeline, compression_mode=False, logging=True, **output_params
+)
+
+# loop over
+while True:
+
+    # read frames from stream
+    (grabbed, frame) = stream.read()
+
+    # check for frame if not grabbed
+    if not grabbed:
+        break
+
+    # {do something with the frame here}
+
+    # write frame to writer
+    writer.write(frame)
+
+    # Show output window
+    cv2.imshow("Output Frame", frame)
 
     # check for 'q' key if pressed
     key = cv2.waitKey(1) & 0xFF

--- a/vidgear/gears/writegear.py
+++ b/vidgear/gears/writegear.py
@@ -234,9 +234,9 @@ class WriteGear:
                     )
                 self.__compression = False  # compression mode disabled
         else:
-            # handle user defined framerate for non-compression mode
+            # handle GStreamer Pipeline Mode for non-compression mode
             gstpipeline_support = self.__output_parameters.pop(
-                "-gstreamer_pipeline_mode", False
+                "-gst_pipeline_mode", False
             )
             if not isinstance(gstpipeline_support, bool):
                 # reset improper values


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->

## Description

Added support for GStreamer pipeline as input string in WriteGear API's Non-Compression mode with new `-gst_pipeline_mode` attribute for its output_params parameter.


### Requirements / Checklist

<!--- By pushing this PR you acknowledge the following: Put an `x` in all the boxes that apply(important): -->

- [x] I have read the [PR Guidelines](https://abhitronix.github.io/vidgear/latest/contribution/PR/#submitting-pull-requestpr-guidelines).
- [x] I have read the [Documentation](https://abhitronix.github.io/vidgear/latest).
- [x] I have updated the documentation accordingly(if required).


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#280 

### Context
<!--- Why is this change required? What problem does it solve? -->
The [OpenCV's VideoWriter Class](https://docs.opencv.org/3.4/dd/d9e/classcv_1_1VideoWriter.html) supports GStreamer input as string to its `output_filename` parameter when `CAP_GSTREAMER` backend is use. This PR adds support for this feature in [WriteGear's Non-Compression mode](https://abhitronix.github.io/vidgear/latest/gears/writegear/non_compression/overview/) that provides flexible way to directly write video frames into GStreamer Pipeline with controlled bitrate. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in the box that apply(important): -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
