### PR TITLE
🐛 StreamGear : Fixed critical logging parameter bug. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ env
 coverage.xml
 .netlify
 .idea
+build/*
+*.egg-info/
+*.egg
 
 # vim temporary files
 *~

--- a/README.md
+++ b/README.md
@@ -680,7 +680,7 @@ It is something I am doing with my own free time. If you would like to say thank
 
 Here is a Bibtex entry you can use to cite this project in a publication:
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5759524.svg)](https://doi.org/10.5281/zenodo.5759524)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6046843.svg)](https://doi.org/10.5281/zenodo.6046843)
 
 ```BibTeX
 @software{vidgear,
@@ -692,13 +692,13 @@ Here is a Bibtex entry you can use to cite this project in a publication:
                   Benjamin Lowe and
                   Mickaël Schoentgen and
                   Renaud Bouckenooghe},
-  title        = {abhiTronix/vidgear: VidGear v0.2.4},
-  month        = dec,
-  year         = 2021,
+  title        = {abhiTronix/vidgear: VidGear v0.2.5},
+  month        = feb,
+  year         = 2022,
   publisher    = {Zenodo},
-  version      = {vidgear-0.2.4},
-  doi          = {10.5281/zenodo.5759524},
-  url          = {https://doi.org/10.5281/zenodo.5759524}
+  version      = {vidgear-0.2.5},
+  doi          = {10.5281/zenodo.6046843},
+  url          = {https://doi.org/10.5281/zenodo.6046843}
 }
 ```
 

--- a/docs/gears/netgear/advanced/bidirectional_mode.md
+++ b/docs/gears/netgear/advanced/bidirectional_mode.md
@@ -516,7 +516,7 @@ client.close()
 &nbsp;
 
 
-## Using Bidirectional Mode for Video-Frames Transfer with Frame Compression :fire:
+### Using Bidirectional Mode for Video-Frames Transfer with Frame Compression :fire:
 
 !!! example "This usage examples can be found [here ➶](../../advanced/compression/#using-bidirectional-mode-for-video-frames-transfer-with-frame-compression)"
 

--- a/docs/gears/netgear/advanced/compression.md
+++ b/docs/gears/netgear/advanced/compression.md
@@ -453,7 +453,7 @@ server.close()
 
 &nbsp; 
 
-## Using Bidirectional Mode for Video-Frames Transfer with Frame Compression :fire:
+### Using Bidirectional Mode for Video-Frames Transfer with Frame Compression :fire:
 
 
 NetGear now supports ==Dual Frame Compression== for transferring video-frames with its exclusive Bidirectional Mode for achieving unmatchable performance bidirectionally. You can easily enable Frame Compression with its performance attributes at both ends to boost performance bidirectionally.

--- a/docs/gears/netgear/advanced/multi_client.md
+++ b/docs/gears/netgear/advanced/multi_client.md
@@ -32,7 +32,7 @@ In Multi-Clients Mode, NetGear robustly handles Multiple Clients at once thereby
 The supported patterns for this mode are Publish/Subscribe (`zmq.PUB/zmq.SUB`) and Request/Reply(`zmq.REQ/zmq.REP`) and can be easily activated in NetGear API through `multiclient_mode` attribute of its [`options`](../../params/#options) dictionary parameter during initialization.
 
 
-!!! tip "Multi-Clients Mode is best for broadcasting **Meta-Data with Video-frames** to specific limited number of clients in real time. But if you're looking to scale broadcast to a very large pool of clients, then see our [WebGear](../../../webgear/overview/) or [WebGear_RTC](../../../webgear_rtc/overview/) APIs."
+!!! alert "Multi-Clients Mode is best for broadcasting **Meta-Data with Video-frames** to specific limited number of clients in real time. But if you're looking to scale broadcast to a very large pool of clients, then see our [WebGear](../../../webgear/overview/) or [WebGear_RTC](../../../webgear_rtc/overview/) APIs."
 
 &nbsp;
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,7 +126,7 @@ It is something I am doing with my own free time. If you would like to say thank
 
 Here is a Bibtex entry you can use to cite this project in a publication:
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5759524.svg)](https://doi.org/10.5281/zenodo.5759524)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6046843.svg)](https://doi.org/10.5281/zenodo.6046843)
 
 ```BibTeX
 @software{vidgear,
@@ -138,13 +138,13 @@ Here is a Bibtex entry you can use to cite this project in a publication:
                   Benjamin Lowe and
                   Mickaël Schoentgen and
                   Renaud Bouckenooghe},
-  title        = {abhiTronix/vidgear: VidGear v0.2.4},
-  month        = dec,
-  year         = 2021,
+  title        = {abhiTronix/vidgear: VidGear v0.2.5},
+  month        = feb,
+  year         = 2022,
   publisher    = {Zenodo},
-  version      = {vidgear-0.2.4},
-  doi          = {10.5281/zenodo.5759524},
-  url          = {https://doi.org/10.5281/zenodo.5759524}
+  version      = {vidgear-0.2.5},
+  doi          = {10.5281/zenodo.6046843},
+  url          = {https://doi.org/10.5281/zenodo.6046843}
 }
 ```
 

--- a/vidgear/gears/streamgear.py
+++ b/vidgear/gears/streamgear.py
@@ -151,14 +151,15 @@ class StreamGear:
 
         # handle Video-Source input
         source = self.__params.pop("-video_source", "")
-        # Check if input is valid
-        if source and isinstance(source, str):
+        # Check if input is valid string
+        if source and isinstance(source, str) and len(source) > 1:
             # Differentiate input
             if os.path.isfile(source):
                 self.__video_source = os.path.abspath(source)
             elif is_valid_url(self.__ffmpeg, url=source, logging=self.__logging):
                 self.__video_source = source
             else:
+                # discard the value otherwise
                 self.__video_source = ""
             # Validate input
             if self.__video_source:
@@ -183,6 +184,7 @@ class StreamGear:
             else:
                 logger.warning("No valid video_source provided.")
         else:
+            # discard the value otherwise
             self.__video_source = ""
 
         # handle user-defined framerate
@@ -949,7 +951,7 @@ class StreamGear:
             stdout=sp.DEVNULL
             if (not self.__video_source and not self.__logging)
             else sp.PIPE,
-            stderr=sp.STDOUT if (self.__video_source and not self.__logging) else None,
+            stderr=None if self.__logging else sp.STDOUT,
         )
         # post handle progress bar and runtime errors in case of video_source
         if self.__video_source:

--- a/vidgear/gears/streamgear.py
+++ b/vidgear/gears/streamgear.py
@@ -368,7 +368,7 @@ class StreamGear:
 
         # write the frame to pipeline
         try:
-            self.__process.stdin.write(frame.tostring())
+            self.__process.stdin.write(frame.tobytes())
         except (OSError, IOError):
             # log something is wrong!
             logger.error(

--- a/vidgear/gears/writegear.py
+++ b/vidgear/gears/writegear.py
@@ -351,7 +351,7 @@ class WriteGear:
 
             # write the frame
             try:
-                self.__process.stdin.write(frame.tostring())
+                self.__process.stdin.write(frame.tobytes())
             except (OSError, IOError):
                 # log something is wrong!
                 logger.error(


### PR DESCRIPTION
<!--- Add a brief title for your PR above -->

## Brief Description
<!--- Provide a brief summary of this PR here -->
This PR fixes critical logging parameter bug which outputs debug logs even when `logging=False` in StreamGear's Real-time Mode.


### Requirements / Checklist
<!--- By pushing this PR you acknowledge the following: Put an `x` in all the boxes that apply(important): -->
- [x] I have read the [PR Guidelines](https://abhitronix.github.io/vidgear/latest/contribution/PR/#submitting-pull-requestpr-guidelines).
- [x] I have read the [Documentation](https://abhitronix.github.io/vidgear/latest).
- [x] I have updated the documentation accordingly(if required).


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#289 

### Context
<!--- Why is this change required? What problem does it solve? -->
There's a hidden bug in StreamGear which incorrectly infers `-video_source` attribute of `stream_params` dictionary parameter as empty when a Zero(0) index camera device is used as input, and even if `logging=False` StreamGear API outputs debug logs. This PR fixes that bug.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in the box that apply(important): -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)