### PR TITLE
Add "How to solve zmq.error.ZMQError" to FAQ

### DIFF
--- a/docs/help/netgear_faqs.md
+++ b/docs/help/netgear_faqs.md
@@ -131,3 +131,9 @@ Here's the compatibility chart for NetGear's [Exclusive Modes](../../gears/netge
 **Answer:** First, carefully go through [NetGear doc ➶](../../gears/netgear/overview/) that contains detailed information. Also, checkout [PyZmq Docs ➶](https://pyzmq.readthedocs.io/en/latest/) for its various settings/parameters. If still it doesn't work for you, then let us know on [Gitter ➶](https://gitter.im/vidgear/community)
 
 &nbsp;
+
+## How to solve `zmq.error.ZMQError` errors?
+
+**Answer:** For those used to the idea that a "server" provides their address to a client, then you should *recheck your preconceptions*! Please read the [Netgear instructions](https://abhitronix.github.io/vidgear/latest/gears/netgear/usage/#using-netgear-with-variable-parameters) carefully, and you will note that it is the client device that defines the IP that is provided to the server config. If you get this the wrong way (using the server IP on the client), then you will get a `zmq.error.ZMQError` error. Make sure it is the **client's IP** shared across the two systems.
+
+&nbsp;


### PR DESCRIPTION
Added a section to the FAQ detailing a possible error if a user uses the server IP in the example code.

## Brief Description
Based on https://github.com/abhiTronix/vidgear/issues/291 where I did not properly parse the instructions, I


### Requirements / Checklist
<!--- By pushing this PR you acknowledge the following: Put an `x` in all the boxes that apply(important): -->
- [x] I have read the [PR Guidelines](https://abhitronix.github.io/vidgear/latest/contribution/PR/#submitting-pull-requestpr-guidelines).
- [x] I have read the [Documentation](https://abhitronix.github.io/vidgear/latest).
- [x] I have updated the documentation accordingly(if required).


### Related Issue

(https://github.com/abhiTronix/vidgear/issues/291)


### Context
Clarifies the potential problems a user may face if they assume servers are the ones that define the IP used.


### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

None of the above, this is just a documentation fix...