### PR TITLE
Make gears into context managers

### DIFF
--- a/vidgear/gears/camgear.py
+++ b/vidgear/gears/camgear.py
@@ -418,6 +418,12 @@ class CamGear:
         # initialize stream read flag event
         self.__stream_read = Event()
 
+    def __enter__(self):
+        return self.start()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+
     def start(self):
         """
         Launches the internal *Threaded Frames Extractor* daemon.

--- a/vidgear/gears/netgear.py
+++ b/vidgear/gears/netgear.py
@@ -925,6 +925,12 @@ class NetGear:
                     "Send Mode is successfully activated and ready to send data."
                 )
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
     def __recv_handler(self):
 
         """

--- a/vidgear/gears/pigear.py
+++ b/vidgear/gears/pigear.py
@@ -191,6 +191,12 @@ class PiGear:
         # initialize termination flag
         self.__terminate = False
 
+    def __enter__(self):
+        return self.start()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+
     def start(self):
         """
         Launches the internal *Threaded Frames Extractor* daemon

--- a/vidgear/gears/screengear.py
+++ b/vidgear/gears/screengear.py
@@ -196,6 +196,12 @@ class ScreenGear:
         # initialize termination flag
         self.__terminate = Event()
 
+    def __enter__(self):
+        return self.start()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+
     def start(self):
         """
         Launches the internal *Threaded Frames Extractor* daemon

--- a/vidgear/gears/stabilizer.py
+++ b/vidgear/gears/stabilizer.py
@@ -146,6 +146,12 @@ class Stabilizer:
         # define normalized box filter
         self.__box_filter = np.ones(smoothing_radius) / smoothing_radius
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.clean()
+
     def stabilize(self, frame):
         """
         This method takes an unstabilized video frame, and returns a stabilized one.

--- a/vidgear/gears/streamgear.py
+++ b/vidgear/gears/streamgear.py
@@ -318,6 +318,12 @@ class StreamGear:
             )
         )
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.terminate()
+
     def stream(self, frame, rgb_mode=False):
         """
         Pipelines `ndarray` frames to FFmpeg Pipeline for transcoding into multi-bitrate streamable assets.

--- a/vidgear/gears/videogear.py
+++ b/vidgear/gears/videogear.py
@@ -152,6 +152,12 @@ class VideoGear:
         # initialize framerate variable
         self.framerate = self.stream.framerate
 
+    def __enter__(self):
+        return self.start()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+
     def start(self):
         """
         Launches the internal *Threaded Frames Extractor* daemon of API in use.

--- a/vidgear/gears/writegear.py
+++ b/vidgear/gears/writegear.py
@@ -300,6 +300,12 @@ class WriteGear:
                 "Compression Mode is disabled, Activating OpenCV built-in Writer!"
             )
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
     def write(self, frame, rgb_mode=False):
 
         """


### PR DESCRIPTION
## Brief Description
This PR adds the `__enter__` and `__exit__` methods to all gears so they can be used as context managers via the `with ... as ...` construct.

### Requirements / Checklist
- [x] I have read the [PR Guidelines](https://abhitronix.github.io/vidgear/latest/contribution/PR/#submitting-pull-requestpr-guidelines).
- [x] I have read the [Documentation](https://abhitronix.github.io/vidgear/latest).
- [ ] I have updated the documentation accordingly(if required).


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#309 

### Context
<!--- Why is this change required? What problem does it solve? -->

This feature would implement the `__enter__()` and `__exit__()` methods for all gears. Internally these only call the gear's `start()` and `close()/stop()/clean()` methods.

There are two major advantages for using Python's context managers instead of calling `start()` and `close()` independently:

- The resource is automatically closed so calling `close()` in the end cannot be forgotten.
- The resource is even closed in case of an exception since the `with` construct runs the contained code as `try ... finally`. The resource is closed in the finally block.

Furthermore:

- It will make the API consistent with other established Python modules/packages, e.g. [`open()`](https://docs.python.org/3/library/functions.html#open), [`threading.Lock`](https://docs.python.org/3/library/threading.html#using-locks-conditions-and-semaphores-in-the-with-statement) or [`pytest.raises()`](https://docs.pytest.org/en/stable/reference/reference.html#pytest.raises)
- It will be backwards compatible since it does not change existing APIs.
- There is no risk involved.
- Future usages will be more correct since the `close()` cannot be forgotten.
- (Opinion) Nicer looking code.

#### Usage example

Simplifying the [NetGear bare-minimum example](https://abhitronix.github.io/vidgear/v0.2.5-stable/gears/netgear/usage/):
```python
# import required libraries
from vidgear.gears import VideoGear
from vidgear.gears import NetGear

# open any valid video stream(for e.g `test.mp4` file)
# Define Netgear Server with default parameters
with VideoGear(source="test.mp4") as stream, NetGear() as server:
    
    # loop over until KeyBoard Interrupted
    while True:
    
        try:
    
            # read frames from stream
            frame = stream.read()
    
            # check for frame if Nonetype
            if frame is None:
                break
    
            # {do something with the frame here}
    
            # send frame to server
            server.send(frame)
    
        except KeyboardInterrupt:
            break

# video stream and server safely closed
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in the box that apply(important): -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)