### PR TITLE
SS: Dash Segments Videos are not supported by OpenCV VideoCapture.

### DIFF
--- a/vidgear/gears/camgear.py
+++ b/vidgear/gears/camgear.py
@@ -46,7 +46,6 @@ if not (yt_dlp is None):
     # import YouTubeDL Parser
     from yt_dlp import YoutubeDL
 
-
     class YT_backend:
         """
         CamGear's Internal YT-DLP Backend Class for extracting metadata from Streaming URLs.
@@ -109,10 +108,10 @@ if not (yt_dlp is None):
 
             # check if source url is supported
             if (
-                    not (self.meta_data is None)  # meta-data is valid
-                    and not ("entries" in self.meta_data)  # playlists are not supported
-                    and len(self.meta_data.get("formats", {}))
-                    > 0  # video formats must exist
+                not (self.meta_data is None)  # meta-data is valid
+                and not ("entries" in self.meta_data)  # playlists are not supported
+                and len(self.meta_data.get("formats", {}))
+                > 0  # video formats must exist
             ):
                 self.is_livestream = self.meta_data.get("is_live", False)
                 self.streams_metadata = self.meta_data.get("formats", {})
@@ -173,20 +172,20 @@ if not (yt_dlp is None):
                     if stream_dim in self.supported_resolutions:
                         stream_res = self.supported_resolutions[stream_dim]
                         if (
-                                not stream_with_audio  # prefer audioless
-                                or stream_protocol in ["https", "http"]  # prefer http/https
-                                or not (
+                            not stream_with_audio  # prefer audioless
+                            or stream_protocol in ["https", "http"]  # prefer http/https
+                            or not (
                                 stream_res in streams
-                        )  # check if already not in dict
+                            )  # check if already not in dict
                         ):
                             streams[stream_res] = stream_url
                     # otherwise make a copy
                     if (
-                            not stream_with_audio  # prefer audioless
-                            or stream_protocol in ["https", "http"]  # prefer http/https
-                            or not (
+                        not stream_with_audio  # prefer audioless
+                        or stream_protocol in ["https", "http"]  # prefer http/https
+                        or not (
                             stream_dim in streams_copy
-                    )  # check if already not in dict
+                        )  # check if already not in dict
                     ):
                         streams_copy[stream_dim] = stream_url
             # use copy to decide best or worst
@@ -208,14 +207,14 @@ class CamGear:
     """
 
     def __init__(
-            self,
-            source=0,
-            stream_mode=False,
-            backend=0,
-            colorspace=None,
-            logging=False,
-            time_delay=0,
-            **options
+        self,
+        source=0,
+        stream_mode=False,
+        backend=0,
+        colorspace=None,
+        logging=False,
+        time_delay=0,
+        **options
     ):
 
         """
@@ -517,7 +516,7 @@ class CamGear:
         return (
             self.frame
             if not self.__terminate.is_set()  # check if already terminated
-               and self.__stream_read.wait(timeout=self.__thread_timeout)  # wait for it
+            and self.__stream_read.wait(timeout=self.__thread_timeout)  # wait for it
             else None
         )
 

--- a/vidgear/gears/camgear.py
+++ b/vidgear/gears/camgear.py
@@ -158,6 +158,8 @@ if not (yt_dlp is None):
                 stream_dim = stream.get("resolution", "")
                 stream_url = stream.get("url", "")
                 stream_protocol = stream.get("protocol", "")
+                if stream_protocol == 'http_dash_segments':
+                    continue
                 stream_with_video = (
                     False if stream.get("vcodec", "none") == "none" else True
                 )

--- a/vidgear/gears/camgear.py
+++ b/vidgear/gears/camgear.py
@@ -158,8 +158,6 @@ if not (yt_dlp is None):
                 stream_dim = stream.get("resolution", "")
                 stream_url = stream.get("url", "")
                 stream_protocol = stream.get("protocol", "")
-                if stream_protocol == 'http_dash_segments':
-                    continue
                 stream_with_video = (
                     False if stream.get("vcodec", "none") == "none" else True
                 )
@@ -167,7 +165,7 @@ if not (yt_dlp is None):
                     False if stream.get("acodec", "none") == "none" else True
                 )
                 # streams must contain video
-                if stream_with_video and stream_dim and stream_url:
+                if stream_with_video and stream_dim and stream_url and stream_protocol != 'http_dash_segments':
                     # check if stream resolution is supported
                     if stream_dim in self.supported_resolutions:
                         stream_res = self.supported_resolutions[stream_dim]

--- a/vidgear/gears/camgear.py
+++ b/vidgear/gears/camgear.py
@@ -165,7 +165,7 @@ if not (yt_dlp is None):
                     False if stream.get("acodec", "none") == "none" else True
                 )
                 # streams must contain video
-                if stream_with_video and stream_dim and stream_url and stream_protocol != 'http_dash_segments':
+                if stream_with_video and stream_dim and stream_url and stream_protocol != "http_dash_segments":
                     # check if stream resolution is supported
                     if stream_dim in self.supported_resolutions:
                         stream_res = self.supported_resolutions[stream_dim]

--- a/vidgear/gears/camgear.py
+++ b/vidgear/gears/camgear.py
@@ -46,6 +46,7 @@ if not (yt_dlp is None):
     # import YouTubeDL Parser
     from yt_dlp import YoutubeDL
 
+
     class YT_backend:
         """
         CamGear's Internal YT-DLP Backend Class for extracting metadata from Streaming URLs.
@@ -108,10 +109,10 @@ if not (yt_dlp is None):
 
             # check if source url is supported
             if (
-                not (self.meta_data is None)  # meta-data is valid
-                and not ("entries" in self.meta_data)  # playlists are not supported
-                and len(self.meta_data.get("formats", {}))
-                > 0  # video formats must exist
+                    not (self.meta_data is None)  # meta-data is valid
+                    and not ("entries" in self.meta_data)  # playlists are not supported
+                    and len(self.meta_data.get("formats", {}))
+                    > 0  # video formats must exist
             ):
                 self.is_livestream = self.meta_data.get("is_live", False)
                 self.streams_metadata = self.meta_data.get("formats", {})
@@ -172,20 +173,20 @@ if not (yt_dlp is None):
                     if stream_dim in self.supported_resolutions:
                         stream_res = self.supported_resolutions[stream_dim]
                         if (
-                            not stream_with_audio  # prefer audioless
-                            or stream_protocol in ["https", "http"]  # prefer http/https
-                            or not (
+                                not stream_with_audio  # prefer audioless
+                                or stream_protocol in ["https", "http"]  # prefer http/https
+                                or not (
                                 stream_res in streams
-                            )  # check if already not in dict
+                        )  # check if already not in dict
                         ):
                             streams[stream_res] = stream_url
                     # otherwise make a copy
                     if (
-                        not stream_with_audio  # prefer audioless
-                        or stream_protocol in ["https", "http"]  # prefer http/https
-                        or not (
+                            not stream_with_audio  # prefer audioless
+                            or stream_protocol in ["https", "http"]  # prefer http/https
+                            or not (
                             stream_dim in streams_copy
-                        )  # check if already not in dict
+                    )  # check if already not in dict
                     ):
                         streams_copy[stream_dim] = stream_url
             # use copy to decide best or worst
@@ -207,14 +208,14 @@ class CamGear:
     """
 
     def __init__(
-        self,
-        source=0,
-        stream_mode=False,
-        backend=0,
-        colorspace=None,
-        logging=False,
-        time_delay=0,
-        **options
+            self,
+            source=0,
+            stream_mode=False,
+            backend=0,
+            colorspace=None,
+            logging=False,
+            time_delay=0,
+            **options
     ):
 
         """
@@ -516,7 +517,7 @@ class CamGear:
         return (
             self.frame
             if not self.__terminate.is_set()  # check if already terminated
-            and self.__stream_read.wait(timeout=self.__thread_timeout)  # wait for it
+               and self.__stream_read.wait(timeout=self.__thread_timeout)  # wait for it
             else None
         )
 


### PR DESCRIPTION
## Brief Description
# Ignoring a Video Protocol not supported by OpenCV


<!--- Provide a brief summary of this PR here -->
Just continuing the loop when stream protocol is of http_dash_segments.
`                
if stream_protocol == 'http_dash_segments':
                    continue
`


### Requirements / Checklist
<!--- By pushing this PR you acknowledge the following: Put an `x` in all the boxes that apply(important): -->
- [x] I have read the [PR Guidelines](https://abhitronix.github.io/vidgear/latest/contribution/PR/#submitting-pull-requestpr-guidelines).
- [x] I have read the [Documentation](https://abhitronix.github.io/vidgear/latest).
- [ ] I have updated the documentation accordingly(if required).


### Context
<!--- Why is this change required? What problem does it solve? -->
I was working on reading frames from youtube when the source URL sometimes failed so I checked, and found that when it failed was solely due to the URL was not supported by OpenCV so resolved that by just continuing the loop in case of HTTP DASH Segments Video

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in the box that applies (important): -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Screenshots (if available):
<!-- Provide screenshots if available or else remove this block -->
![Screenshot from 2022-06-16 12-14-03](https://user-images.githubusercontent.com/19831283/174067405-49315d89-7d65-453d-85ca-658c8bc87e70.png)

