### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/gears/netgear/advanced/multi_client.md
+++ b/docs/gears/netgear/advanced/multi_client.md
@@ -85,7 +85,7 @@ The supported patterns for this mode are Publish/Subscribe (`zmq.PUB/zmq.SUB`) a
 
 ### Bare-Minimum Usage
 
-In this example, we will capturing live video-frames from a source _(a.k.a Server)_ with a webcam connected to it. Afterwards, those captured frame will be sent over the network to two independent system _(a.k.a Clients)_ using this Multi-Clients Mode in NetGear API. Finally, both Clients will be displaying recieved frames in Output Windows in real time.
+In this example, we will capturing live video-frames from a source _(a.k.a Server)_ with a webcam connected to it. Afterwards, those captured frame will be sent over the network to two independent system _(a.k.a Clients)_ using this Multi-Clients Mode in NetGear API. Finally, both Clients will be displaying received frames in Output Windows in real time.
 
 !!! tip "This example is useful for building applications like Real-Time Video Broadcasting to multiple clients in local network."
 
@@ -145,7 +145,7 @@ while True:
         # send frame and also receive data from Client(s)
         recv_data = server.send(frame)
 
-        # check if valid data recieved
+        # check if valid data received
         if not (recv_data is None):
             # extract unique port address and its respective data
             unique_address, data = recv_data
@@ -343,7 +343,7 @@ while True:
         # send frame and also receive data from Client(s)
         recv_data = server.send(frame)
 
-        # check if valid data recieved
+        # check if valid data received
         if not (recv_data is None):
             # extract unique port address and its respective data
             unique_address, data = recv_data
@@ -555,7 +555,7 @@ while True:
         # send frame and also receive data from Client(s)
         recv_data = server.send(frame)
 
-        # check if valid data recieved
+        # check if valid data received
         if not (recv_data is None):
             # extract unique port address and its respective data
             unique_address, data = recv_data
@@ -786,7 +786,7 @@ while True:
         # send frame & data and also receive data from Client(s)
         recv_data = server.send(frame, message=target_data) # (1)
 
-        # check if valid data recieved
+        # check if valid data received
         if not (recv_data is None):
             # extract unique port address and its respective data
             unique_address, data = recv_data

--- a/docs/help/general_faqs.md
+++ b/docs/help/general_faqs.md
@@ -55,7 +55,7 @@ Once done, visit [Switching from OpenCV ➶](../../switch_from_cv/) to easily re
 
 ## How to log to a file in VidGear?
 
-**Answer:** VidGear provides exclusive **`VIDGEAR_LOGFILE`** environment variable to enable logging to a file while logging is enabled _(i.e. `logging=True`)_ on respective Gear. You just have to set ==directory pathname _(automatically creates `vidgear.log` file)_== or a ==log file pathname== itself as value for this  environment variable. This can be done on various platfroms/OSes as follows:
+**Answer:** VidGear provides exclusive **`VIDGEAR_LOGFILE`** environment variable to enable logging to a file while logging is enabled _(i.e. `logging=True`)_ on respective Gear. You just have to set ==directory pathname _(automatically creates `vidgear.log` file)_== or a ==log file pathname== itself as value for this  environment variable. This can be done on various platforms/OSes as follows:
 
 !!! info "Remember enabling this logging to a file will completely disable any output on the terminal." 
 

--- a/docs/help/stabilizer_ex.md
+++ b/docs/help/stabilizer_ex.md
@@ -254,17 +254,17 @@ from vidgear.gears.stabilizer import Stabilizer
 import cv2
 
 # Give suitable video file path to be stabilized
-unstablized_videofile = "test.mp4"
+unstabilized_videofile = "test.mp4"
 
 # open stream on given path
-stream = cv2.VideoCapture(unstablized_videofile)
+stream = cv2.VideoCapture(unstabilized_videofile)
 
 # initiate stabilizer object with defined parameters
 stab = Stabilizer(smoothing_radius=30, crop_n_zoom=True, border_size=5, logging=True)
 
 # define required FFmpeg optimizing parameters for your writer
 output_params = {
-    "-i": unstablized_videofile,
+    "-i": unstabilized_videofile,
     "-c:a": "aac",
     "-input_framerate": stream.get(cv2.CAP_PROP_FPS),
     "-clones": ["-shortest"],

--- a/docs/help/videogear_ex.md
+++ b/docs/help/videogear_ex.md
@@ -240,14 +240,14 @@ from vidgear.gears import VideoGear
 import cv2
 
 # Give suitable video file path to be stabilized
-unstablized_videofile = "test.mp4"
+unstabilized_videofile = "test.mp4"
 
 # open any valid video path with stabilization enabled(`stabilize = True`)
-stream_stab = VideoGear(source=unstablized_videofile, stabilize=True, logging=True).start()
+stream_stab = VideoGear(source=unstabilized_videofile, stabilize=True, logging=True).start()
 
 # define required FFmpeg optimizing parameters for your writer
 output_params = {
-    "-i": unstablized_videofile,
+    "-i": unstabilized_videofile,
     "-c:a": "aac",
     "-input_framerate": stream_stab.framerate,
     "-clones": ["-shortest"],

--- a/docs/help/writegear_ex.md
+++ b/docs/help/writegear_ex.md
@@ -387,7 +387,7 @@ In this example we are capturing video from desktop screen in a Timely Accurate 
 
 We will be using [`cv_bridge`](http://wiki.ros.org/cv_bridge/Tutorials/ConvertingBetweenROSImagesAndOpenCVImagesPython) to convert OpenCV frames to ROS image messages and vice-versa. 
 
-In this example, we'll create a node that listens to a ROS image message topic, converts the recieved images messages into OpenCV frames, draws a circle on it, and then process these frames into a lossless compressed file format in real-time.
+In this example, we'll create a node that listens to a ROS image message topic, converts the received images messages into OpenCV frames, draws a circle on it, and then process these frames into a lossless compressed file format in real-time.
 
 ??? new "New in v0.2.2" 
     This example was added in `v0.2.2`.
@@ -420,7 +420,7 @@ class image_subscriber:
         self.writer = WriteGear(output_filename=output_filename)
 
     def callback(self, data):
-        # convert recieved data to frame
+        # convert received data to frame
         try:
             cv_image = self.bridge.imgmsg_to_cv2(data, "bgr8")
         except CvBridgeError as e:

--- a/docs/help/writegear_faqs.md
+++ b/docs/help/writegear_faqs.md
@@ -105,7 +105,7 @@ limitations under the License.
 
 &nbsp;
 
-## Is YouTube-Live Streaming possibe with WriteGear?
+## Is YouTube-Live Streaming possible with WriteGear?
 
 **Answer:** Yes, See [this bonus example ➶](../writegear_ex/#using-writegears-compression-mode-for-youtube-live-streaming).
 

--- a/vidgear/gears/netgear.py
+++ b/vidgear/gears/netgear.py
@@ -820,7 +820,7 @@ class NetGear:
                             protocol + "://" + str(address) + ":" + str(pt)
                         )
                 else:
-                    # handle SSH tuneling if enabled
+                    # handle SSH tunneling if enabled
                     if self.__ssh_tunnel_mode:
                         # establish tunnel connection
                         ssh.tunnel_connection(

--- a/vidgear/gears/pigear.py
+++ b/vidgear/gears/pigear.py
@@ -212,7 +212,7 @@ class PiGear:
 
     def __timeit(self):
         """
-        Threaded Internal Timer that keep checks on thread excecution timing
+        Threaded Internal Timer that keep checks on thread execution timing
         """
 
         # assign current time

--- a/vidgear/tests/network_tests/test_netgear.py
+++ b/vidgear/tests/network_tests/test_netgear.py
@@ -389,7 +389,7 @@ def test_bidirectional_mode(pattern, target_data, options):
             server_data, frame_client = client.recv(return_data=target_data)
             # server receives the data and cycle continues
             client_data = server.send(target_data)
-            # test if recieved successfully
+            # test if received successfully
             assert not (client_data is None), "Test Failed!"
         else:
             # get frame from stream
@@ -525,7 +525,7 @@ def test_multiserver_mode(pattern, options):
         )
         client_frame_dict[unique_address] = frame
 
-        # check if recieved frames from each unique server exactly matches input frame
+        # check if received frames from each unique server exactly matches input frame
         for key in client_frame_dict.keys():
             assert np.array_equal(frame_server, client_frame_dict[key])
 

--- a/vidgear/tests/writer_tests/test_compression_mode.py
+++ b/vidgear/tests/writer_tests/test_compression_mode.py
@@ -151,7 +151,7 @@ def test_input_framerate(c_ffmpeg):
 )
 def test_write(conversion):
     """
-    Testing WriteGear Compression-Mode(FFmpeg) Writer capabilties in different colorspace with CamGearAPI.
+    Testing WriteGear Compression-Mode(FFmpeg) Writer capabilities in different colorspace with CamGearAPI.
     """
     try:
         # Open stream


### PR DESCRIPTION
There are small typos in:
- docs/gears/netgear/advanced/multi_client.md
- docs/help/general_faqs.md
- docs/help/stabilizer_ex.md
- docs/help/videogear_ex.md
- docs/help/writegear_ex.md
- docs/help/writegear_faqs.md
- vidgear/gears/netgear.py
- vidgear/gears/pigear.py
- vidgear/tests/network_tests/test_netgear.py
- vidgear/tests/writer_tests/test_compression_mode.py

Fixes:
- Should read `unstabilized` rather than `unstablized`.
- Should read `received` rather than `recieved`.
- Should read `tunneling` rather than `tuneling`.
- Should read `possible` rather than `possibe`.
- Should read `platforms` rather than `platfroms`.
- Should read `execution` rather than `excecution`.
- Should read `capabilities` rather than `capabilties`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md