### PR TITLE
🧑‍💻 Maintenance: Log current vidgear version when vidgear APIs are called, not at import. (Fixes #338)

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -82,6 +82,7 @@ jobs:
         if: success() && matrix.python-version == 3.7
       - name: pytest without_ENV
         run: |
+          sudo modprobe v4l2loopback devices=1 video_nr=0 exclusive_caps=1 card_label='VCamera'
           timeout 1200 pytest --verbose --cov=vidgear --cov-report=xml  --cov-report term-missing vidgear/tests/ || code=$?; if [[ $code -ne 124 && $code -ne 0 ]]; then exit $code; else echo "EXIT_CODE=$code" >>$GITHUB_ENV; fi
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         if: success() && matrix.python-version != 3.7

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -50,6 +50,7 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -qq unzip wget -y
           sudo apt-get install -qq dos2unix -y
+          sudo apt-get install ffmpeg v4l2loopback-dkms v4l2loopback-utils linux-modules-extra-$(uname -r) -y
       - name: prepare bash_scripts
         run: |
           dos2unix scripts/bash/prepare_dataset.sh

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,7 @@ limitations under the License.
 """
 # import the necessary packages
 import json
-import sys
 import platform
-import setuptools
 import urllib.request
 
 from pkg_resources import parse_version
@@ -63,7 +61,7 @@ def latest_version(package_name):
         versions = list(data["releases"].keys())
         versions.sort(key=parse_version)
         return ">={}".format(versions[-1])
-    except TypeError as e:
+    except Exception as e:
         if versions:
             return ">={}".format(versions[-1])
     return ""

--- a/vidgear/gears/asyncio/helper.py
+++ b/vidgear/gears/asyncio/helper.py
@@ -23,12 +23,9 @@ limitations under the License.
 # import the necessary packages
 import os
 import cv2
-import errno
-import numpy as np
-import asyncio
-import logging as log
-import platform
 import requests
+import numpy as np
+import logging as log
 from tqdm import tqdm
 from colorlog import ColoredFormatter
 from requests.adapters import HTTPAdapter

--- a/vidgear/gears/asyncio/netgear_async.py
+++ b/vidgear/gears/asyncio/netgear_async.py
@@ -30,7 +30,7 @@ import platform
 from collections import deque
 
 # import helper packages
-from ..helper import logger_handler, import_dependency_safe
+from ..helper import logger_handler, import_dependency_safe, logcurr_vidgear_ver
 
 # import additional API(s)
 from ..videogear import VideoGear
@@ -126,8 +126,13 @@ class NetGear_Async:
             time_delay (int): time delay (in sec) before start reading the frames.
             options (dict): provides ability to alter Tweak Parameters of NetGear_Async, CamGear, PiGear & Stabilizer.
         """
+        # print current version
+        logcurr_vidgear_ver(logging=logging)
+
         # raise error(s) for critical Class imports
-        import_dependency_safe("zmq" if zmq is None else "", min_version="4.0", pkg_name="pyzmq")
+        import_dependency_safe(
+            "zmq" if zmq is None else "", min_version="4.0", pkg_name="pyzmq"
+        )
         import_dependency_safe("msgpack" if msgpack is None else "")
         import_dependency_safe("msgpack_numpy" if m is None else "")
 

--- a/vidgear/gears/asyncio/webgear.py
+++ b/vidgear/gears/asyncio/webgear.py
@@ -33,7 +33,12 @@ from .helper import (
     generate_webdata,
     create_blank_frame,
 )
-from ..helper import logger_handler, retrieve_best_interpolation, import_dependency_safe
+from ..helper import (
+    logger_handler,
+    retrieve_best_interpolation,
+    import_dependency_safe,
+    logcurr_vidgear_ver,
+)
 
 # import additional API(s)
 from ..videogear import VideoGear
@@ -105,6 +110,9 @@ class WebGear:
             time_delay (int): time delay (in sec) before start reading the frames.
             options (dict): provides ability to alter Tweak Parameters of WebGear, CamGear, PiGear & Stabilizer.
         """
+        # print current version
+        logcurr_vidgear_ver(logging=logging)
+
         # raise error(s) for critical Class imports
         import_dependency_safe("starlette" if starlette is None else "")
         import_dependency_safe(

--- a/vidgear/gears/asyncio/webgear_rtc.py
+++ b/vidgear/gears/asyncio/webgear_rtc.py
@@ -33,7 +33,12 @@ from .helper import (
     generate_webdata,
     create_blank_frame,
 )
-from ..helper import logger_handler, retrieve_best_interpolation, import_dependency_safe
+from ..helper import (
+    logger_handler,
+    retrieve_best_interpolation,
+    import_dependency_safe,
+    logcurr_vidgear_ver,
+)
 
 # import additional API(s)
 from ..videogear import VideoGear
@@ -111,6 +116,8 @@ if not (aiortc is None):
                 time_delay (int): time delay (in sec) before start reading the frames.
                 options (dict): provides ability to alter Tweak Parameters of WebGear_RTC, CamGear, PiGear & Stabilizer.
             """
+            # print current version
+            logcurr_vidgear_ver(logging=logging)
 
             super().__init__()  # don't forget this!
 
@@ -265,7 +272,7 @@ if not (aiortc is None):
                     interpolation=self.__interpolation,
                 )
 
-            # construct `av.frame.Frame` from `numpy.nd.array` 
+            # construct `av.frame.Frame` from `numpy.nd.array`
             # based on available channels in frames
             f_format = "bgr24"
             if f_stream.ndim == 3 and f_stream.shape[-1] == 4:

--- a/vidgear/gears/camgear.py
+++ b/vidgear/gears/camgear.py
@@ -33,6 +33,7 @@ from .helper import (
     get_supported_resolution,
     check_gstreamer_support,
     import_dependency_safe,
+    logcurr_vidgear_ver,
 )
 
 # define logger
@@ -232,6 +233,8 @@ class CamGear:
             time_delay (int): time delay (in sec) before start reading the frames.
             options (dict): provides ability to alter Source Tweak Parameters.
         """
+        # print current version
+        logcurr_vidgear_ver(logging=logging)
 
         # enable logging if specified
         self.__logging = False

--- a/vidgear/gears/helper.py
+++ b/vidgear/gears/helper.py
@@ -92,13 +92,35 @@ def logger_handler():
     return handler
 
 
+# global var to check
+# if version is logged
+ver_is_logged = False
+
 # define logger
 logger = log.getLogger("Helper")
 logger.propagate = False
 logger.addHandler(logger_handler())
 logger.setLevel(log.DEBUG)
-# log current version for debugging
-logger.info("Running VidGear Version: {}".format(str(__version__)))
+
+
+def logcurr_vidgear_ver(logging=False):
+    """
+    ## logcurr_vidgear_ver
+
+    A auxiliary function to log current vidgear version for debugging.
+
+    Parameters:
+        logging (bool): enables logging for its operations
+    """
+    # making changes to global var
+    global ver_is_logged
+    # log current vidgear version
+    logging and not (ver_is_logged) and logger.info(
+        "Running VidGear Version: {}".format(str(__version__))
+    )
+    # disable logging same thing again
+    if logging and not (ver_is_logged):
+        ver_is_logged = True
 
 
 def get_module_version(module=None):
@@ -514,11 +536,7 @@ def get_supported_pixfmts(path):
     # find all outputs
     outputs = finder.findall("\n".join(supported_pxfmts))
     # return output findings
-    return [
-        [s for s in o[0].split(" ")][-1]
-        for o in outputs
-        if len(o) == 3
-    ]
+    return [[s for s in o[0].split(" ")][-1] for o in outputs if len(o) == 3]
 
 
 def is_valid_url(path, url=None, logging=False):

--- a/vidgear/gears/netgear.py
+++ b/vidgear/gears/netgear.py
@@ -19,7 +19,6 @@ limitations under the License.
 """
 # import the necessary packages
 import os
-import cv2
 import time
 import string
 import secrets
@@ -36,6 +35,7 @@ from .helper import (
     check_WriteAccess,
     check_open_port,
     import_dependency_safe,
+    logcurr_vidgear_ver,
 )
 
 # safe import critical Class modules
@@ -132,8 +132,13 @@ class NetGear:
             logging (bool): enables/disables logging.
             options (dict): provides the flexibility to alter various NetGear internal properties.
         """
+        # print current version
+        logcurr_vidgear_ver(logging=logging)
+
         # raise error(s) for critical Class imports
-        import_dependency_safe("zmq" if zmq is None else "", min_version="4.0", pkg_name="pyzmq")
+        import_dependency_safe(
+            "zmq" if zmq is None else "", min_version="4.0", pkg_name="pyzmq"
+        )
         import_dependency_safe(
             "simplejpeg" if simplejpeg is None else "", error="log", min_version="1.6.1"
         )

--- a/vidgear/gears/pigear.py
+++ b/vidgear/gears/pigear.py
@@ -25,7 +25,12 @@ import logging as log
 from threading import Thread
 
 # import helper packages
-from .helper import capPropId, logger_handler, import_dependency_safe
+from .helper import (
+    capPropId,
+    logger_handler,
+    import_dependency_safe,
+    logcurr_vidgear_ver,
+)
 
 # safe import critical Class modules
 picamera = import_dependency_safe("picamera", error="silent")
@@ -74,6 +79,9 @@ class PiGear:
             time_delay (int): time delay (in sec) before start reading the frames.
             options (dict): provides ability to alter Source Tweak Parameters.
         """
+        # print current version
+        logcurr_vidgear_ver(logging=logging)
+
         # raise error(s) for critical Class imports
         import_dependency_safe(
             "picamera" if picamera is None else "",

--- a/vidgear/gears/screengear.py
+++ b/vidgear/gears/screengear.py
@@ -19,15 +19,19 @@ limitations under the License.
 """
 # import the necessary packages
 import cv2
-import time
 import queue
 import numpy as np
 import logging as log
 from threading import Thread, Event
-from collections import deque, OrderedDict
+from collections import OrderedDict
 
 # import helper packages
-from .helper import import_dependency_safe, capPropId, logger_handler
+from .helper import (
+    import_dependency_safe,
+    capPropId,
+    logger_handler,
+    logcurr_vidgear_ver,
+)
 
 # safe import critical Class modules
 mss = import_dependency_safe("from mss import mss", error="silent")
@@ -65,8 +69,13 @@ class ScreenGear:
             logging (bool): enables/disables logging.
             options (dict): provides the flexibility to manually set the dimensions of capture screen area.
         """
+        # print current version
+        logcurr_vidgear_ver(logging=logging)
+
         # raise error(s) for critical Class imports
-        import_dependency_safe("from mss import mss" if mss is None else "", pkg_name="mss")
+        import_dependency_safe(
+            "from mss import mss" if mss is None else "", pkg_name="mss"
+        )
         import_dependency_safe("pyscreenshot" if pysct is None else "")
 
         # enable logging if specified:

--- a/vidgear/gears/stabilizer.py
+++ b/vidgear/gears/stabilizer.py
@@ -27,7 +27,12 @@ import logging as log
 from collections import deque
 
 # import helper packages
-from .helper import logger_handler, check_CV_version, retrieve_best_interpolation
+from .helper import (
+    logger_handler,
+    check_CV_version,
+    retrieve_best_interpolation,
+    logcurr_vidgear_ver,
+)
 
 # define logger
 logger = log.getLogger("Stabilizer")
@@ -65,6 +70,8 @@ class Stabilizer:
             crop_n_zoom (bool): enables croping and zooming of frames(to original size) to reduce the black borders.
             logging (bool): enables/disables logging.
         """
+        # print current version
+        logcurr_vidgear_ver(logging=logging)
 
         # initialize deques for handling input frames and its indexes
         self.__frame_queue = deque(maxlen=smoothing_radius)

--- a/vidgear/gears/streamgear.py
+++ b/vidgear/gears/streamgear.py
@@ -19,7 +19,6 @@ limitations under the License.
 """
 # import the necessary packages
 import os
-import cv2
 import time
 import math
 import platform
@@ -44,6 +43,7 @@ from .helper import (
     check_WriteAccess,
     get_video_bitrate,
     get_valid_ffmpeg_path,
+    logcurr_vidgear_ver,
 )
 
 # define logger
@@ -81,6 +81,9 @@ class StreamGear:
             logging (bool): enables/disables logging.
             stream_params (dict): provides the flexibility to control supported internal parameters and FFmpeg properities.
         """
+        # print current version
+        logcurr_vidgear_ver(logging=logging)
+
         # checks if machine in-use is running windows os or not
         self.__os_windows = True if os.name == "nt" else False
         # enable logging if specified

--- a/vidgear/gears/videogear.py
+++ b/vidgear/gears/videogear.py
@@ -22,7 +22,7 @@ limitations under the License.
 import logging as log
 
 # import helper packages
-from .helper import logger_handler
+from .helper import logger_handler, logcurr_vidgear_ver
 
 # import additional API(s)
 from .camgear import CamGear
@@ -80,6 +80,8 @@ class VideoGear:
             time_delay (int): time delay (in sec) before start reading the frames.
             options (dict): provides ability to alter Tweak Parameters of CamGear, PiGear & Stabilizer.
         """
+        # print current version
+        logcurr_vidgear_ver(logging=logging)
 
         # initialize stabilizer
         self.__stablization_mode = stabilize

--- a/vidgear/gears/writegear.py
+++ b/vidgear/gears/writegear.py
@@ -20,7 +20,6 @@ limitations under the License.
 # import the necessary packages
 import os
 import cv2
-import sys
 import time
 import platform
 import pathlib
@@ -38,6 +37,7 @@ from .helper import (
     get_supported_pixfmts,
     get_supported_vencoders,
     check_gstreamer_support,
+    logcurr_vidgear_ver,
 )
 
 # define logger
@@ -94,6 +94,13 @@ class WriteGear:
             logging (bool): enables/disables logging.
             output_params (dict): provides the flexibility to control supported internal parameters and FFmpeg properities.
         """
+        # print current version
+        logcurr_vidgear_ver(logging=logging)
+
+        # check if user not using depreciated `output_filename` parameter
+        assert (
+            not "output_filename" in output_params
+        ), "[WriteGear:ERROR] :: The `output_filename` parameter has been renamed to `output`. Refer Docs for more info."
 
         # assign parameter values to class variables
         # enables compression if enabled

--- a/vidgear/gears/writegear.py
+++ b/vidgear/gears/writegear.py
@@ -326,24 +326,26 @@ class WriteGear:
                 "Compression Mode with FFmpeg backend is configured properly."
             )
         else:
-            if self.__out_file is None:
-                # check if GStreamer Pipeline Mode is enabled
-                if gstpipeline_mode:
-                    # enforce GStreamer backend
-                    self.__output_parameters["-backend"] = "CAP_GSTREAMER"
-                    # assign original ouput value
-                    self.__out_file = output
-                    # log it
-                    self.__logging and logger.debug(
-                        "Non-Compression Mode is successfully configured in GStreamer Pipeline Mode."
+            # raise error if not valid input
+            if self.__out_file is None and not gstpipeline_mode:
+                raise ValueError(
+                    "[WriteGear:ERROR] :: output value:`{}` is not supported in Non-Compression Mode.".format(
+                        output
                     )
-                else:
-                    # raise error otherwise
-                    raise ValueError(
-                        "[WriteGear:ERROR] :: output value:`{}` is not supported in Non-Compression Mode.".format(
-                            output
-                        )
-                    )
+                )
+
+            # check if GStreamer Pipeline Mode is enabled
+            if gstpipeline_mode:
+                # enforce GStreamer backend
+                self.__output_parameters["-backend"] = "CAP_GSTREAMER"
+                # enforce original output value
+                self.__out_file = output
+
+            # log it
+            self.__logging and logger.debug(
+                "Non-Compression Mode is successfully configured in GStreamer Pipeline Mode."
+            )
+
             # log if Compression is disabled
             logger.critical(
                 "Compression Mode is disabled, Activating OpenCV built-in Writer!"

--- a/vidgear/tests/writer_tests/test_non_compression_mode.py
+++ b/vidgear/tests/writer_tests/test_non_compression_mode.py
@@ -89,9 +89,7 @@ def test_write(conversion):
     Testing VidGear Non-Compression(OpenCV) Mode Writer
     """
     stream = cv2.VideoCapture(return_testvideo_path())
-    writer = WriteGear(
-        output="Output_twc.avi", compression_mode=False
-    )  # Define writer
+    writer = WriteGear(output="Output_twc.avi", compression_mode=False)  # Define writer
     while True:
         (grabbed, frame) = stream.read()
         # read frames
@@ -153,7 +151,9 @@ test_data_class = [
     ),
     (
         "appsrc ! videoconvert ! avenc_mpeg4 bitrate=100000 ! mp4mux ! filesink location=foo.mp4",
-        {"-gst_pipeline_mode": True},
+        {"-gst_pipeline_mode": True}
+        if platform.system() == "Linux"
+        else {"-gst_pipeline_mode": "invalid"},
         True if platform.system() == "Linux" else False,
     ),
 ]
@@ -167,10 +167,7 @@ def test_WriteGear_compression(f_name, output_params, result):
     try:
         stream = cv2.VideoCapture(return_testvideo_path())
         writer = WriteGear(
-            output=f_name,
-            compression_mode=False,
-            logging=True,
-            **output_params
+            output=f_name, compression_mode=False, logging=True, **output_params
         )
         while True:
             (grabbed, frame) = stream.read()


### PR DESCRIPTION
<!--- Add a brief title for your PR above -->

## Brief Description
This PR will add functionality to log current vidgear version once only when vidgear APIs are called, not at import. Less clutter in logs.

### Requirements / Checklist
<!--- By pushing this PR you acknowledge the following: Put an `x` in all the boxes that apply(important): -->
- [x] I have read the [PR Guidelines](https://abhitronix.github.io/vidgear/latest/contribution/PR/#submitting-pull-requestpr-guidelines).
- [x] I have read the [Documentation](https://abhitronix.github.io/vidgear/latest).
- [x] I have updated the documentation accordingly(if required).


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#338 
#340

### Context
<!--- Why is this change required? What problem does it solve? -->
This PR is aimed at reducing unnecessary logging of vidgear current version on importing its APIs. With this PR, user can now completely turn off logging and  moreover APIs with logging turned on (`logging=True`) will automatically log version only once when called within code, thus serving both purposes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in the box that apply(important): -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
