### PR TITLE
⚡️ WebGear: Added way to completely disable Data-Files Auto-Generation WorkFlow. (Fixes #339)

### DIFF
--- a/docs/gears/webgear/overview.md
+++ b/docs/gears/webgear/overview.md
@@ -18,7 +18,7 @@ limitations under the License.
 ===============================================
 -->
 
-# WebGear API 
+# WebGear API
 
 <figure>
   <img src="../../../assets/gifs/webgear.gif" alt="WebGear in action!" loading="lazy" width=100%/>
@@ -27,9 +27,9 @@ limitations under the License.
 
 ## Overview
 
-> *WebGear is a powerful [ASGI](https://asgi.readthedocs.io/en/latest/) Video-Broadcaster API ideal for transmitting [Motion-JPEG](https://en.wikipedia.org/wiki/Motion_JPEG)-frames from a single source to multiple recipients via the browser.*
+> _WebGear is a powerful [ASGI](https://asgi.readthedocs.io/en/latest/) Video-Broadcaster API ideal for transmitting [Motion-JPEG](https://en.wikipedia.org/wiki/Motion_JPEG)-frames from a single source to multiple recipients via the browser._
 
-WebGear API works on [**Starlette**](https://www.starlette.io/)'s ASGI application and provides a highly extensible and flexible async wrapper around its complete framework. WebGear can flexibly interact with Starlette's ecosystem of shared middleware, mountable applications, [Response classes](https://www.starlette.io/responses/), [Routing tables](https://www.starlette.io/routing/), [Static Files](https://www.starlette.io/staticfiles/), [Templating engine(with Jinja2)](https://www.starlette.io/templates/), etc. 
+WebGear API works on [**Starlette**](https://www.starlette.io/)'s ASGI application and provides a highly extensible and flexible async wrapper around its complete framework. WebGear can flexibly interact with Starlette's ecosystem of shared middleware, mountable applications, [Response classes](https://www.starlette.io/responses/), [Routing tables](https://www.starlette.io/routing/), [Static Files](https://www.starlette.io/staticfiles/), [Templating engine(with Jinja2)](https://www.starlette.io/templates/), etc.
 
 WebGear API uses an intraframe-only compression scheme under the hood where the sequence of video-frames are first encoded as JPEG-DIB (JPEG with Device-Independent Bit compression) and then streamed over HTTP using Starlette's Multipart [Streaming Response](https://www.starlette.io/responses/#streamingresponse) and a [Uvicorn](https://www.uvicorn.org/#quickstart) ASGI Server. This method imposes lower processing and memory requirements, but the quality is not the best, since JPEG compression is not very efficient for motion video.
 
@@ -39,56 +39,60 @@ In layman's terms, WebGear acts as a powerful ==**Video Broadcaster**== that tra
 
 ## Data-Files Auto-Generation WorkFlow for WebGear
 
-On initializing WebGear API, it automatically checks for three critical **data files**(i.e `index.html`, `404.html` & `500.html`) inside the `templates` folder of the `webgear` directory at the [*default location*](#default-location) which gives rise to the following two possible scenario:
+??? tip "Disabling Auto-Generation process in WebGear"
+
+    Starting with vidgear `v0.3.0`, you can now completely disable Auto-Generation process in WebGear API using [`skip_generate_webdata`](../params/#webgear-specific-attributes) dictionary boolean attribute. When `{skip_generate_webdata:True}`, no default data files will be downloaded or validated during initialization.
+
+    !!! warning "Only `/video` route is available when `{skip_generate_webdata:True}` in WebGear API. All other default routes will be JSONResponses with `404`/`500` status codes."
+
+On initializing WebGear API, it automatically checks for three critical **data files**(i.e `index.html`, `404.html` & `500.html`) inside the `templates` folder of the `webgear` directory at the [_default location_](#default-location) which gives rise to the following two possible scenario:
 
 - [x] **If data-files found:** it will proceed normally for instantiating the Starlette application.
 - [ ] **If data-files not found:** it will trigger the [**Auto-Generation process**](#auto-generation-process)
 
 ### Default Location
 
-* A _default location_ is the path of the directory where data files/folders are downloaded/generated/saved.
-* By default, the `.vidgear` the folder at the home directory of your machine _(for e.g `/home/foo/.vidgear` on Linux)_ serves as the _default location_.
-* But you can also use WebGear's [`custom_data_location`](../params/#webgear-specific-attributes) dictionary attribute to change/alter *default location* path to somewhere else.
+- A _default location_ is the path of the directory where data files/folders are downloaded/generated/saved.
+- By default, the `.vidgear` the folder at the home directory of your machine _(for e.g `/home/foo/.vidgear` on Linux)_ serves as the _default location_.
+- But you can also use WebGear's [`custom_data_location`](../params/#webgear-specific-attributes) dictionary attribute to change/alter _default location_ path to somewhere else.
 
 	!!! tip
-			You can set [`logging=True`](../params/#logging) during initialization, for easily identifying the selected _default location_, which will be something like this _(on a Linux machine)_:
+			You can set [`logging=True`](../params/#logging) during initialization, for easily identifying the selected _default location_, which will be something like this _(on a Linux machine)_
 
-		  ```sh
-		  WebGear :: DEBUG :: `/home/foo/.vidgear` is the default location for saving WebGear data-files.
-		  ```
+			```sh
+			WebGear :: DEBUG :: `/home/foo/.vidgear` is the default location for saving WebGear data-files.
+			```
 
 ### Auto-Generation process
 
 !!! info
 
-	* You can also force trigger the Auto-generation process to overwrite existing data-files using [`overwrite_default_files`](../params/#webgear-specific-attributes) dictionary attribute. Remember, only downloaded default data files(given above) will be overwritten in this process but any other file/folder will NOT be affected.
+    * You can also force trigger the Auto-generation process to overwrite existing data-files using [`overwrite_default_files`](../params/#webgear-specific-attributes) dictionary attribute. Remember, only downloaded default data files(given above) will be overwritten in this process but any other file/folder will NOT be affected.
 
-	* It is advised to enable logging(`logging=True`) on the first run for easily identifying any runtime errors
+    * It is advised to enable logging(`logging=True`) on the first run for easily identifying any runtime errors
 
-
-* On triggering this process, WebGear API creates `webgear` directory, and `templates` and `static` folders inside along with `js`, `css`, `img` sub-folders at the assigned [*default location*](#default-location).
-* Thereby at this [*default location*](#default-location), the necessary default data files will be downloaded from a dedicated [**Github Server**](https://github.com/abhiTronix/vidgear-vitals) inside respective folders in the following order:
+- On triggering this process, WebGear API creates `webgear` directory, and `templates` and `static` folders inside along with `js`, `css`, `img` sub-folders at the assigned [_default location_](#default-location).
+- Thereby at this [_default location_](#default-location), the necessary default data files will be downloaded from a dedicated [**Github Server**](https://github.com/abhiTronix/vidgear-vitals) inside respective folders in the following order:
 
 	```sh
-		.vidgear
-		└── webgear
-		    ├── static
-		    │   ├── css
-		    │   │   └── custom.css
-		    │   ├── img
-		    │   │   └── favicon-32x32.png
-		    │   └── js
-		    │       └── custom.js
-		    └── templates
-		        ├── 404.html
-		        ├── 500.html
-		        ├── base.html
-		        └── index.html
-		6 directories, 7 files
+	.vidgear
+	└── webgear
+	    ├── static
+	    │   ├── css
+	    │   │   └── custom.css
+	    │   ├── img
+	    │   │   └── favicon-32x32.png
+	    │   └── js
+	    │       └── custom.js
+	    └── templates
+	        ├── 404.html
+	        ├── 500.html
+	        ├── base.html
+	        └── index.html
+	6 directories, 7 files
 	```
 
-* Finally these downloaded files thereby are verified for errors and API proceeds for instantiating the Starlette application normally.
-
+- Finally these downloaded files thereby are verified for errors and API proceeds for instantiating the Starlette application normally.
 
 &nbsp;
 
@@ -108,32 +112,30 @@ from vidgear.gears.asyncio import WebGear
 
 ## WebGear's Default Template
 
-??? new "New in v0.2.1" 
-	New Standalone **WebGear's Default Theme** was added in `v0.2.1`.
+??? new "New in v0.2.1"
+New Standalone **WebGear's Default Theme** was added in `v0.2.1`.
 
 The WebGear API by default uses simple & elegant [**WebGear's Default Theme**](https://github.com/abhiTronix/vidgear-vitals#webgear-default-theme) which looks like something as follows:
 
 ### Index.html
 
-*Can be accessed by visiting WebGear app server, running at http://localhost:8000/:*
+_Can be accessed by visiting WebGear app server, running at http://localhost:8000/:_
 
 <h2 align="center">
   <img src="../../../assets/images/webgear_temp_index.png" loading="lazy" alt="WebGear default Index page"/>
 </h2>
 
-
 ### 404.html
 
-*Appears when respective URL is not found, for example http://localhost:8000/ok:*
+_Appears when respective URL is not found, for example http://localhost:8000/ok:_
 
 <h2 align="center">
   <img src="../../../assets/images/webgear_temp_404.png" loading="lazy" alt="WebGear default 404 page"/>
 </h2>
 
-
 ### 500.html
 
-*Appears when an API Error is encountered:*
+_Appears when an API Error is encountered:_
 
 !!! warning "If [`logging`](../params/#logging) is enabled and an error occurs, then instead of displaying this 500 handler, WebGear will respond with a traceback response."
 
@@ -151,7 +153,6 @@ The WebGear API by default uses simple & elegant [**WebGear's Default Theme**](h
 
 !!! example "After going through WebGear Usage Examples, Checkout more bonus examples [here ➶](../../../help/webgear_ex/)"
 
-
 ## Parameters
 
 <div>
@@ -163,7 +164,6 @@ The WebGear API by default uses simple & elegant [**WebGear's Default Theme**](h
 <div>
 <a href="../../../bonus/reference/webgear/">See here 🚀</a>
 </div>
-
 
 ## FAQs
 

--- a/docs/gears/webgear/params.md
+++ b/docs/gears/webgear/params.md
@@ -146,6 +146,18 @@ This parameter can be used to pass user-defined parameter to WebGear API by form
     WebGear(logging=True, **options)
     ```
 
+* **`skip_generate_webdata`** _(boolean)_ : Can be used to completely disable Data-Files Auto-Generation WorkFlow in WebGear API, and thereby no default data files will be downloaded or validated during its initialization. Its default value is `False`. Its usage is as follows
+
+    ??? new "New in v0.3.0"
+        `skip_generate_webdata` attribute was added in `v0.3.0`.
+
+    ```python
+    # completely disable Data-Files Auto-Generation WorkFlow
+    options = {"skip_generate_webdata": True}
+    # assign it
+    WebGear(logging=True, **options)
+    ```
+
 &nbsp; 
 
 &nbsp;

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,10 @@ def latest_version(package_name):
     url = "https://pypi.python.org/pypi/%s/json" % (package_name,)
     versions = []
     try:
-        response = urllib.request.urlopen(urllib.request.Request(url), timeout=1)
+        response = urllib.request.urlopen(
+            urllib.request.Request(url),
+            timeout=1,
+        )
         data = json.load(response)
         versions = list(data["releases"].keys())
         versions.sort(key=parse_version)
@@ -64,6 +67,8 @@ def latest_version(package_name):
     except Exception as e:
         if versions:
             return ">={}".format(versions[-1])
+        else:
+            print(str(e))
     return ""
 
 

--- a/vidgear/gears/__init__.py
+++ b/vidgear/gears/__init__.py
@@ -2,7 +2,7 @@
 import sys
 import types
 import importlib
-from distutils.version import LooseVersion
+from pkg_resources import parse_version
 
 
 def get_module_version(module=None):
@@ -105,7 +105,7 @@ def import_core_dependency(
         module_version = get_module_version(module_to_get)
         # verify
         if mode == "exact":
-            if LooseVersion(module_version) != LooseVersion(version):
+            if parse_version(module_version) != parse_version(version):
                 # create message
                 msg = "Unsupported version '{}' found. Vidgear requires '{}' dependency with exact version '{}' installed!".format(
                     module_version, parent_module, version
@@ -113,7 +113,7 @@ def import_core_dependency(
                 # raise
                 raise ImportError(msg)
         elif mode == "lte":
-            if LooseVersion(module_version) > LooseVersion(version):
+            if parse_version(module_version) > parse_version(version):
                 # create message
                 msg = "Unsupported version '{}' found. Vidgear requires '{}' dependency installed with older version '{}' or smaller!".format(
                     module_version, parent_module, version
@@ -121,7 +121,7 @@ def import_core_dependency(
                 # raise
                 raise ImportError(msg)
         else:
-            if LooseVersion(module_version) < LooseVersion(version):
+            if parse_version(module_version) < parse_version(version):
                 # create message
                 msg = "Unsupported version '{}' found. Vidgear requires '{}' dependency installed with newer version '{}' or greater!".format(
                     module_version, parent_module, version

--- a/vidgear/gears/asyncio/webgear.py
+++ b/vidgear/gears/asyncio/webgear.py
@@ -47,7 +47,7 @@ from ..videogear import VideoGear
 starlette = import_dependency_safe("starlette", error="silent")
 if not (starlette is None):
     from starlette.routing import Mount, Route
-    from starlette.responses import StreamingResponse
+    from starlette.responses import StreamingResponse, JSONResponse
     from starlette.templating import Jinja2Templates
     from starlette.staticfiles import StaticFiles
     from starlette.applications import Starlette
@@ -120,6 +120,7 @@ class WebGear:
         )
 
         # initialize global params
+        self.__skip_generate_webdata = False  # generate webdata by default
         # define frame-compression handler
         self.__jpeg_compression_quality = 90  # 90% quality
         self.__jpeg_compression_fastdct = True  # fastest DCT on by default
@@ -142,6 +143,16 @@ class WebGear:
 
         # assign values to global variables if specified and valid
         if options:
+            # check whether to disable Data-Files Auto-Generation WorkFlow
+            if "skip_generate_webdata" in options:
+                value = options["skip_generate_webdata"]
+                # enable jpeg fastdct
+                if isinstance(value, bool):
+                    self.__skip_generate_webdata = value
+                else:
+                    logger.warning("Skipped invalid `skip_generate_webdata` value!")
+                del options["skip_generate_webdata"]  # clean
+
             if "jpeg_compression_colorspace" in options:
                 value = options["jpeg_compression_colorspace"]
                 if isinstance(value, str) and value.strip().upper() in [
@@ -235,45 +246,61 @@ class WebGear:
                     logger.warning("Skipped invalid `enable_infinite_frames` value!")
                 del options["enable_infinite_frames"]  # clean
 
-        # check if custom certificates path is specified
-        if custom_data_location:
-            data_path = generate_webdata(
-                custom_data_location,
-                c_name="webgear",
-                overwrite_default=overwrite_default,
-                logging=logging,
+        # check if disable Data-Files Auto-Generation WorkFlow is disabled
+        if not self.__skip_generate_webdata:
+            # check if custom data path is specified
+            if custom_data_location:
+                data_path = generate_webdata(
+                    custom_data_location,
+                    c_name="webgear",
+                    overwrite_default=overwrite_default,
+                    logging=logging,
+                )
+            else:
+                # otherwise generate suitable path
+                data_path = generate_webdata(
+                    os.path.join(expanduser("~"), ".vidgear"),
+                    c_name="webgear",
+                    overwrite_default=overwrite_default,
+                    logging=logging,
+                )
+
+            # log it
+            self.__logging and logger.debug(
+                "`{}` is the default location for saving WebGear data-files.".format(
+                    data_path
+                )
             )
+            # define Jinja2 templates handler
+            self.__templates = Jinja2Templates(
+                directory="{}/templates".format(data_path)
+            )
+            # define routing tables
+            self.routes = [
+                Route("/", endpoint=self.__homepage),
+                Route("/video", endpoint=self.__video),
+                Mount(
+                    "/static",
+                    app=StaticFiles(directory="{}/static".format(data_path)),
+                    name="static",
+                ),
+            ]
         else:
-            # otherwise generate suitable path
-            data_path = generate_webdata(
-                os.path.join(expanduser("~"), ".vidgear"),
-                c_name="webgear",
-                overwrite_default=overwrite_default,
-                logging=logging,
+            # log it
+            self.__logging and logger.critical(
+                "WebGear Data-Files Auto-Generation WorkFlow has been manually disabled."
             )
-
-        # log it
-        self.__logging and logger.debug(
-            "`{}` is the default location for saving WebGear data-files.".format(
-                data_path
+            # define routing tables
+            self.routes = [
+                Route("/video", endpoint=self.__video),
+            ]
+            # log it
+            self.__logging and logger.warning(
+                "Only `/video` route is available for this instance."
             )
-        )
-
-        # define Jinja2 templates handler
-        self.__templates = Jinja2Templates(directory="{}/templates".format(data_path))
 
         # define custom exception handlers
         self.__exception_handlers = {404: self.__not_found, 500: self.__server_error}
-        # define routing tables
-        self.routes = [
-            Route("/", endpoint=self.__homepage),
-            Route("/video", endpoint=self.__video),
-            Mount(
-                "/static",
-                app=StaticFiles(directory="{}/static".format(data_path)),
-                name="static",
-            ),
-        ]
         # define middleware support
         self.middleware = []
         # Handle video source
@@ -435,7 +462,7 @@ class WebGear:
 
     async def __video(self, scope):
         """
-        Return a async video streaming response.
+        Returns a async video streaming response.
         """
         assert scope["type"] in ["http", "https"]
         return StreamingResponse(
@@ -445,24 +472,45 @@ class WebGear:
 
     async def __homepage(self, request):
         """
-        Return an HTML index page.
+        Returns an HTML index page.
         """
-        return self.__templates.TemplateResponse("index.html", {"request": request})
+        return (
+            self.__templates.TemplateResponse("index.html", {"request": request})
+            if not self.__skip_generate_webdata
+            else JSONResponse(
+                {"detail": "WebGear Data-Files Auto-Generation WorkFlow is disabled!"},
+                status_code=404,
+            )
+        )
 
     async def __not_found(self, request, exc):
         """
-        Return an HTML 404 page.
+        Returns an HTML 404 page.
         """
-        return self.__templates.TemplateResponse(
-            "404.html", {"request": request}, status_code=404
+        return (
+            self.__templates.TemplateResponse(
+                "404.html", {"request": request}, status_code=404
+            )
+            if not self.__skip_generate_webdata
+            else JSONResponse(
+                {"detail": "WebGear Data-Files Auto-Generation WorkFlow is disabled!"},
+                status_code=404,
+            )
         )
 
     async def __server_error(self, request, exc):
         """
-        Return an HTML 500 page.
+        Returns an HTML 500 page.
         """
-        return self.__templates.TemplateResponse(
-            "500.html", {"request": request}, status_code=500
+        return (
+            self.__templates.TemplateResponse(
+                "500.html", {"request": request}, status_code=500
+            )
+            if not self.__skip_generate_webdata
+            else JSONResponse(
+                {"detail": "WebGear Data-Files Auto-Generation WorkFlow is disabled!"},
+                status_code=500,
+            )
         )
 
     def shutdown(self):

--- a/vidgear/gears/asyncio/webgear.py
+++ b/vidgear/gears/asyncio/webgear.py
@@ -19,12 +19,10 @@ limitations under the License.
 """
 # import the necessary packages
 import os
-import cv2
 import asyncio
 import inspect
 import numpy as np
 import logging as log
-from collections import deque
 from os.path import expanduser
 
 # import helper packages
@@ -120,7 +118,7 @@ class WebGear:
         )
 
         # initialize global params
-        self.__skip_generate_webdata = False  # generate webdata by default
+        self.__skip_generate_webdata = False  # generate webgear data by default
         # define frame-compression handler
         self.__jpeg_compression_quality = 90  # 90% quality
         self.__jpeg_compression_fastdct = True  # fastest DCT on by default
@@ -294,7 +292,7 @@ class WebGear:
             self.routes = [
                 Route("/video", endpoint=self.__video),
             ]
-            # log it
+            # log exceptions
             self.__logging and logger.warning(
                 "Only `/video` route is available for this instance."
             )

--- a/vidgear/gears/asyncio/webgear_rtc.py
+++ b/vidgear/gears/asyncio/webgear_rtc.py
@@ -19,12 +19,10 @@ limitations under the License.
 """
 # import the necessary packages
 import os
-import cv2
 import time
 import fractions
 import asyncio
 import logging as log
-from collections import deque
 from os.path import expanduser
 
 # import helper packages

--- a/vidgear/gears/helper.py
+++ b/vidgear/gears/helper.py
@@ -39,9 +39,8 @@ from tqdm import tqdm
 from contextlib import closing
 from pathlib import Path
 from colorlog import ColoredFormatter
-from distutils.version import LooseVersion
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from pkg_resources import parse_version
+from requests.adapters import HTTPAdapter, Retry
 from ..version import __version__
 
 
@@ -234,7 +233,7 @@ def import_dependency_safe(
         # extract version
         version = get_module_version(module_to_get)
         # verify
-        if LooseVersion(version) < LooseVersion(min_version):
+        if parse_version(version) < parse_version(min_version):
             # create message
             msg = """Unsupported version '{}' found. Vidgear requires '{}' dependency installed with version '{}' or greater. 
             Update it with  `pip install -U {}` command.""".format(
@@ -279,7 +278,7 @@ def check_CV_version():
 
     **Returns:** OpenCV's version first bit
     """
-    if LooseVersion(cv2.__version__) >= LooseVersion("4"):
+    if parse_version(cv2.__version__) >= parse_version("4"):
         return 4
     else:
         return 3


### PR DESCRIPTION
<!--- Add a brief title for your PR above -->

## Brief Description
<!--- Provide a brief summary of this PR here -->
This PR will add feature to completely disable Data-Files Auto-Generation WorkFlow in WebGear API.


### Requirements / Checklist
<!--- By pushing this PR you acknowledge the following: Put an `x` in all the boxes that apply(important): -->
- [x] I have read the [PR Guidelines](https://abhitronix.github.io/vidgear/latest/contribution/PR/#submitting-pull-requestpr-guidelines).
- [x] I have read the [Documentation](https://abhitronix.github.io/vidgear/latest).
- [x] I have updated the documentation accordingly(if required).


### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#339

### Context
<!--- Why is this change required? What problem does it solve? -->
This PR will add new `skip_generate_webdata` boolean optional attribute(`False` by default) to completely disable Data-Files Auto-Generation WorkFlow in WebGear API, that will only enables `/video` route by default. This feature will also implement JSONResponse as placeholder response instead of Index, 404 and 500 HTML pages, when workflow is disabled. (Note: Index HTML page will also throw 404 status code.)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in the box that apply(important): -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)